### PR TITLE
added validation for logger setter

### DIFF
--- a/API.md
+++ b/API.md
@@ -24,7 +24,7 @@
     - [`send(message, queue, [options, [callback]])`](#sendmessage-queue-options-callback)
     - [`get(queue, [options, [callback]])`](#getqueue-options-callback)
   - [Events](#Events)
-    -[Examples](#Examples)
+    - [Examples](#Examples)
   
 ##BunnyBus
 
@@ -67,7 +67,7 @@ bunnybus.config = { server : 'red-bee.cloudamqp.com'};
 
 ###`logger`
 
-Setter and Getter for logger.  By default, `BunnyBus` will instantiate and set a logger using the `EventEmitter`.  When a custom logger is set, `BunnyBus` will **no** longer emit log messages.
+Setter and Getter for logger.  By default, `BunnyBus` will instantiate and set a logger using the `EventEmitter`.  When a custom logger is set, `BunnyBus` will **no** longer emit log messages through the `EventEmitter`.  The Setter will also validate the contract of the logger to ensure the following keys exist [`debug`, `info`, `warn`, `error`, `fatal`] and are of type `Function`.  When validation fails, logger will fail to set.
 
 ```Javascript
 const BunnyBus = require('bunnybus');

--- a/lib/helpers/index.js
+++ b/lib/helpers/index.js
@@ -6,5 +6,6 @@ module.exports = {
     convertToBuffer       : require('./convertToBuffer'),
     createTransactionId   : require('./createTransactionId'),
     cleanObject           : require('./cleanObject'),
-    reduceCallback        : require('./reduceCallback')
+    reduceCallback        : require('./reduceCallback'),
+    validateLoggerContract: require('./validateLoggerContract')
 };

--- a/lib/helpers/validateLoggerContract.js
+++ b/lib/helpers/validateLoggerContract.js
@@ -1,0 +1,16 @@
+'use strict';
+
+const validLevels = ['debug', 'info', 'warn', 'error', 'fatal'];
+
+const validateLoggerContract = (logger) => {
+
+    for (const level of validLevels) {
+        if (typeof logger[level] !== 'function') {
+            return false;
+        }
+    }
+
+    return true;
+};
+
+module.exports = validateLoggerContract;

--- a/lib/index.js
+++ b/lib/index.js
@@ -86,8 +86,9 @@ class BunnyBus extends EventEmitter{
 
     set logger(value) {
 
-//TODO should do some sort of validation here that value has the contract expected.
-        internals.instance._logger = value;
+        if (Helpers.validateLoggerContract(value)) {
+            internals.instance._logger = value;
+        }
     }
 
     get connectionString() {

--- a/test/assertions/assertValidateLoggerContract.js
+++ b/test/assertions/assertValidateLoggerContract.js
@@ -1,0 +1,16 @@
+'use strict';
+
+const Helpers = require('../../lib/helpers');
+const Code = require('code');
+const expect = Code.expect;
+
+const assertValidateLoggerContract = (logger, expectation, callback) => {
+
+    const result = Helpers.validateLoggerContract(logger);
+
+    expect(result).to.equal(expectation);
+
+    callback();
+};
+
+module.exports = assertValidateLoggerContract;

--- a/test/assertions/index.js
+++ b/test/assertions/index.js
@@ -9,5 +9,6 @@ module.exports = {
     assertReduceCallback          : require('./assertReduceCallback'),
     assertUndefinedReduceCallback : require('./assertUndefinedReduceCallback'),
     assertLogger                  : require('./assertLogger'),
-    assertCustomLogger            : require('./assertCustomLogger')
+    assertCustomLogger            : require('./assertCustomLogger'),
+    assertValidateLoggerContract  : require('./assertValidateLoggerContract')
 };

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -5,11 +5,23 @@ const Lab = require('lab');
 const Async = require('async');
 const Assertions = require('./assertions');
 const Helpers = require('../lib/helpers');
+const EventLogger = require('../lib/loggers').EventLogger;
 
 const lab = exports.lab = Lab.script();
 const describe = lab.describe;
 const it = lab.it;
 const expect = Code.expect;
+
+const FakeLoggerFactory = (...levels) => {
+
+    const logger = {};
+
+    for (const level of levels) {
+        logger[level] = () => {};
+    }
+
+    return logger;
+};
 
 describe('helpers', () => {
 
@@ -183,6 +195,44 @@ describe('helpers', () => {
 
             Assertions.assertUndefinedReduceCallback();
             done();
+        });
+    });
+
+    describe('validateLoggerContract', () => {
+
+        it('should return true when validating EventLogger', (done) => {
+
+            Assertions.assertValidateLoggerContract(new EventLogger(), true, done);
+        });
+
+        it('should return true when validating custom logger object', (done) => {
+
+            Assertions.assertValidateLoggerContract(FakeLoggerFactory('debug', 'info', 'warn', 'error', 'fatal'), true, done);
+        });
+
+        it('should return false when validating custom logger missing debug', (done) => {
+
+            Assertions.assertValidateLoggerContract(FakeLoggerFactory('info', 'warn', 'error', 'fatal'), false, done);
+        });
+
+        it('should return false when validating custom logger missing info', (done) => {
+
+            Assertions.assertValidateLoggerContract(FakeLoggerFactory('debug', 'warn', 'error', 'fatal'), false, done);
+        });
+
+        it('should return false when validating custom logger missing warn', (done) => {
+
+            Assertions.assertValidateLoggerContract(FakeLoggerFactory('debug', 'info', 'error', 'fatal'), false, done);
+        });
+
+        it('should return false when validating custom logger missing error', (done) => {
+
+            Assertions.assertValidateLoggerContract(FakeLoggerFactory('debug', 'info', 'warn', 'fatal'), false, done);
+        });
+
+        it('should return false when validating custom logger missing fatal', (done) => {
+
+            Assertions.assertValidateLoggerContract(FakeLoggerFactory('debug', 'info', 'warn', 'error'), false, done);
         });
     });
 });

--- a/test/logging.js
+++ b/test/logging.js
@@ -25,53 +25,59 @@ describe('logging', () => {
         done();
     });
 
-    it('should subscribe to `log.info` event when log.info() is called', (done) => {
+    describe('with default logger', () => {
 
-        Assertions.assertLogger(instance, 'info', inputMessage, done);
+        it('should subscribe to `log.info` event when log.info() is called', (done) => {
+
+            Assertions.assertLogger(instance, 'info', inputMessage, done);
+        });
+
+        it('should subscribe to `log.error` event when log.error() is called', (done) => {
+
+            Assertions.assertLogger(instance, 'error', inputMessage, done);
+        });
+
+        it('should subscribe to `log.warn` event when log.warn() is called', (done) => {
+
+            Assertions.assertLogger(instance, 'warn', inputMessage, done);
+        });
+
+        it('should subscribe to `log.fatal` event when log.fatal() is called', (done) => {
+
+            Assertions.assertLogger(instance, 'fatal', inputMessage, done);
+        });
+
+        it('should subscribe to `log.debug` event when log.debug() is called', (done) => {
+
+            Assertions.assertLogger(instance, 'debug', inputMessage, done);
+        });
     });
 
-    it('should subscribe to `log.error` event when log.error() is called', (done) => {
+    describe('with custom logger', () => {
 
-        Assertions.assertLogger(instance, 'error', inputMessage, done);
-    });
+        it('should call custom info handler', (done) => {
 
-    it('should subscribe to `log.warn` event when log.warn() is called', (done) => {
+            Assertions.assertCustomLogger(instance, 'info', inputMessage, done);
+        });
 
-        Assertions.assertLogger(instance, 'warn', inputMessage, done);
-    });
+        it('should call custom error handler', (done) => {
 
-    it('should subscribe to `log.fatal` event when log.fatal() is called', (done) => {
+            Assertions.assertCustomLogger(instance, 'error', inputMessage, done);
+        });
 
-        Assertions.assertLogger(instance, 'fatal', inputMessage, done);
-    });
+        it('should call custom warn handler', (done) => {
 
-    it('should subscribe to `log.debug` event when log.debug() is called', (done) => {
+            Assertions.assertCustomLogger(instance, 'warn', inputMessage, done);
+        });
 
-        Assertions.assertLogger(instance, 'debug', inputMessage, done);
-    });
+        it('should call custom fatal handler', (done) => {
 
-    it('should call custom info handler', (done) => {
+            Assertions.assertCustomLogger(instance, 'fatal', inputMessage, done);
+        });
 
-        Assertions.assertCustomLogger(instance, 'info', inputMessage, done);
-    });
+        it('should call custom debug handler', (done) => {
 
-    it('should call custom error handler', (done) => {
-
-        Assertions.assertCustomLogger(instance, 'error', inputMessage, done);
-    });
-
-    it('should call custom warn handler', (done) => {
-
-        Assertions.assertCustomLogger(instance, 'warn', inputMessage, done);
-    });
-
-    it('should call custom fatal handler', (done) => {
-
-        Assertions.assertCustomLogger(instance, 'fatal', inputMessage, done);
-    });
-
-    it('should call custom debug handler', (done) => {
-
-        Assertions.assertCustomLogger(instance, 'debug', inputMessage, done);
+            Assertions.assertCustomLogger(instance, 'debug', inputMessage, done);
+        });
     });
 });


### PR DESCRIPTION
## Description
Added a contract validator in the setter for `logger`.  The contract validator will check that the logger has the following methods : [`debug`, `info`, `warn`, `error`, `fatal`].  The validation will work for a simple javascript object instantiated as `{}` or via `new ClassName()`.  If the setter fails to validate, the internal logger will not be replaced.

## Related Issue
- #2 

## Motivation and Context
To ensure user customization of the logger does not hinder the runtime of BunnyBus.  Safe defaults are set and used already and will be relied on when custom logging devices do not work as expected.

## Types of changes
- [x] Documentation only (no changes to either `lib/` or `test/` files)
- [ ] Bug fix (non-breaking change which fixes an issue. you didn't modify existing tests)
- [x] New feature (non-breaking change which adds functionality. you added at least one new test)
- [ ] Breaking change (fix or feature that would cause existing functionality to change. you had to modify existing tests.)

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/xogroup/bunnybus/blob/master/.github/CONTRIBUTING.md) document.
- [x] My code follows the [Hapi.js style guide](https://github.com/hapijs/contrib/blob/master/Style.md).
- [x] I have updated the documentation as needed.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.