### PR TITLE
Refactor promise passthrough

### DIFF
--- a/lib/helpers/toPromise.js
+++ b/lib/helpers/toPromise.js
@@ -1,10 +1,8 @@
 'use strict';
 
-const toPromise = (instance, method, ...args) => {
+const toPromise = (promise, method, ...args) => {
 
-    const PromiseImplementation = instance.promise;
-
-    return new PromiseImplementation((resolve, reject) => {
+    return new promise((resolve, reject) => {
 
         args.push((err, data) => {
 

--- a/lib/helpers/validatePromiseContract.js
+++ b/lib/helpers/validatePromiseContract.js
@@ -10,11 +10,20 @@ const validatePromiseContract = function (promiseImplementation) {
         resolve = res;
         reject = rej;
     });
-    const isThenable = typeof task.then === 'function';
-    const isCatchable = typeof task.catch === 'function';
-    const isResolvable = typeof resolve === 'function' && typeof reject === 'function';
 
-    return isResolvable && isThenable && isCatchable;
+    if (typeof task.then !== 'function') {
+        return false;
+    }
+
+    if (typeof task.catch !== 'function') {
+        return false;
+    }
+
+    if (typeof resolve !== 'function' && typeof reject !== 'function') {
+        return false;
+    }
+
+    return true;
 };
 
 module.exports = validatePromiseContract;

--- a/lib/index.js
+++ b/lib/index.js
@@ -81,10 +81,10 @@ class BunnyBus extends EventEmitter{
         return $._promise;
     }
 
-    set promise(promiseImplementation) {
+    set promise(value) {
 
-        if (Helpers.validatePromiseContract(promiseImplementation)) {
-            $._promise = promiseImplementation;
+        if (Helpers.validatePromiseContract(value)) {
+            $._promise = value;
         }
     }
 
@@ -136,7 +136,7 @@ class BunnyBus extends EventEmitter{
         callback = Helpers.reduceCallback(callback);
 
         if (callback === undefined) {
-            return Helpers.toPromise($, $.createConnection);
+            return Helpers.toPromise($.promise, $.createConnection);
         }
 console.log('creating connection');
         Async.waterfall([
@@ -165,7 +165,7 @@ console.log('creating connection');
         callback = Helpers.reduceCallback(callback);
 
         if (callback === undefined) {
-            return Helpers.toPromise($, $.closeConnection);
+            return Helpers.toPromise($.promise, $.closeConnection);
         }
 console.log('closing connection');
         Async.waterfall([
@@ -195,7 +195,7 @@ console.log('closing connection');
         callback = Helpers.reduceCallback(callback);
 
         if (callback === undefined) {
-            return Helpers.toPromise($, $.createChannel);
+            return Helpers.toPromise($.promise, $.createChannel);
         }
 console.log('creating channel');
         Async.waterfall([
@@ -234,7 +234,7 @@ console.log('creating channel');
         callback = Helpers.reduceCallback(callback);
 
         if (callback === undefined) {
-            return Helpers.toPromise($, $.closeChannel);
+            return Helpers.toPromise($.promise, $.closeChannel);
         }
 console.log('closing channel');
         if ($.hasChannel) {
@@ -257,7 +257,7 @@ console.log('closing channel');
         callback = Helpers.reduceCallback(options, callback);
 
         if (callback === undefined) {
-            return Helpers.toPromise($, $.createExchange, name, type, options);
+            return Helpers.toPromise($.promise, $.createExchange, name, type, options);
         }
 console.log('creating exchange');
         if (!$.hasChannel) {
@@ -274,7 +274,7 @@ console.log('creating exchange');
         callback = Helpers.reduceCallback(options, callback);
 
         if (callback === undefined) {
-            return Helpers.toPromise($, $.deleteExchange, name, options);
+            return Helpers.toPromise($.promise, $.deleteExchange, name, options);
         }
 console.log('deleting exchange', name);
         if (!$.hasChannel) {
@@ -290,7 +290,7 @@ console.log('deleting exchange', name);
         callback = Helpers.reduceCallback(callback);
 
         if (callback === undefined) {
-            return Helpers.toPromise($, $.checkExchange, name);
+            return Helpers.toPromise($.promise, $.checkExchange, name);
         }
 
         if (!$.hasChannel) {
@@ -310,7 +310,7 @@ console.log('deleting exchange', name);
         callback = Helpers.reduceCallback(options, callback);
 
         if (callback === undefined) {
-            return Helpers.toPromise($, $.createQueue, name, options);
+            return Helpers.toPromise($.promise, $.createQueue, name, options);
         }
 console.log('creating queue');
         if (!$.hasChannel) {
@@ -326,7 +326,7 @@ console.log('creating queue');
         callback = Helpers.reduceCallback(options, callback);
 
         if (callback === undefined) {
-            return Helpers.toPromise($, $.deleteQueue, name, options);
+            return Helpers.toPromise($.promise, $.deleteQueue, name, options);
         }
 console.log('deleting queue', name);
         if (!$.hasChannel) {
@@ -342,7 +342,7 @@ console.log('deleting queue', name);
         callback = Helpers.reduceCallback(callback);
 
         if (callback === undefined) {
-            return Helpers.toPromise($, $.checkQueue, name);
+            return Helpers.toPromise($.promise, $.checkQueue, name);
         }
 
         if (!$.hasChannel) {
@@ -358,7 +358,7 @@ console.log('deleting queue', name);
         callback = Helpers.reduceCallback(options, callback);
 
         if (callback === undefined) {
-            return Helpers.toPromise($, $.send, message, queue, options);
+            return Helpers.toPromise($.promise, $.send, message, queue, options);
         }
 console.log('sending');
         //TODO rename callingModule to source
@@ -401,7 +401,7 @@ console.log('sending');
         callback = Helpers.reduceCallback(options, callback);
 
         if (callback === undefined) {
-            return Helpers.toPromise($, $.get, queue, options);
+            return Helpers.toPromise($.promise, $.get, queue, options);
         }
 console.log('getting', queue);
         if (!$.hasChannel) {
@@ -417,7 +417,7 @@ console.log('getting', queue);
         callback = Helpers.reduceCallback(options, callback);
 
         if (callback === undefined) {
-            return Helpers.toPromise($, $.publish, message, options);
+            return Helpers.toPromise($.promise, $.publish, message, options);
         }
 console.log('publishing');
         const globalExchange = (options && options.globalExchange) || $.config.globalExchange;
@@ -472,7 +472,7 @@ console.log('publishing');
         callback = Helpers.reduceCallback(options, callback);
 
         if (callback === undefined) {
-            return Helpers.toPromise($, $.subscribe, queue, handlers, options);
+            return Helpers.toPromise($.promise, $.subscribe, queue, handlers, options);
         }
 
         const $S = $._state.subscriptions;
@@ -559,7 +559,7 @@ console.log('generic handler just updated subscription');
         callback = Helpers.reduceCallback(callback);
 
         if (callback === undefined) {
-            return Helpers.toPromise($, $.unsubscribe, queue);
+            return Helpers.toPromise($.promise, $.unsubscribe, queue);
         }
 console.log('unsubscribing', queue);
         const $S = $._state.subscriptions;
@@ -582,7 +582,7 @@ console.log('unsubscribing', queue);
         callback = Helpers.reduceCallback(options, callback);
 
         if (callback === undefined) {
-            return Helpers.toPromise($, $._ack, payload, options);
+            return Helpers.toPromise($.promise, $._ack, payload, options);
         }
 console.log('acking');
         if (!$.hasChannel) {
@@ -599,7 +599,7 @@ console.log('acking');
         callback = Helpers.reduceCallback(options, callback);
 
         if (callback === undefined) {
-            return Helpers.toPromise($, $._requeue, payload, queue, options);
+            return Helpers.toPromise($.promise, $._requeue, payload, queue, options);
         }
 console.log('requeuing');
         const routeKey = options && options.routeKey ? options.routeKey : null;
@@ -636,7 +636,7 @@ console.log('requeuing');
         callback = Helpers.reduceCallback(options, callback);
 
         if (callback === undefined) {
-            return Helpers.toPromise($, $._reject, payload, errorQueue, options);
+            return Helpers.toPromise($.promise, $._reject, payload, errorQueue, options);
         }
 console.log('rejecting');
         const queue = errorQueue || $.config.server.errorQueue;
@@ -671,7 +671,7 @@ console.log('rejecting');
         callback = Helpers.reduceCallback(callback);
 
         if (callback === undefined) {
-            return Helpers.toPromise($, $._autoConnectChannel);
+            return Helpers.toPromise($.promise, $._autoConnectChannel);
         }
 console.log('auto connecting');
         if ($.hasConnection || $.hasChannel) {

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -10,8 +10,6 @@ const Helpers = require('../lib/helpers');
 const EventLogger = require('../lib/loggers').EventLogger;
 
 const lab = exports.lab = Lab.script();
-const before = lab.before;
-const after = lab.after;
 const describe = lab.describe;
 const it = lab.it;
 const expect = Code.expect;
@@ -271,46 +269,15 @@ describe('helpers', () => {
 
     describe('toPromise', () => {
 
-        const BunnyBus = require('../lib');
-        const callbackFunction = (cb) => {
+        const callback = () => {};
 
-            return cb();
-        };
-        let instance = undefined;
-
-        before((done) => {
-
-            instance = new BunnyBus();
-            instance.config = BunnyBus.DEFAULT_SERVER_CONFIGURATION;
-            done();
-        });
-
-        after((done) => {
-
-            instance.promise = Promise;
-            done();
-        });
-
-        describe('default native Promise', () => {
+        describe('ES6 Promise', () => {
 
             it('should promisify methods using the native implementation', (done) => {
 
-                expect(instance.promise).to.equal(Promise);
+                //expect(instance.promise).to.equal(Promise);
 
-                const task = Helpers.toPromise(instance, callbackFunction);
-
-                expect(task).to.be.instanceof(Promise);
-                expect(task.then).to.be.a.function();
-                done();
-            });
-
-            it('should fallback to default native promise if unsupported implementation is used', (done) => {
-
-                instance.promise = Q;
-
-                expect(instance.promise).to.equal(Promise);
-
-                const task = Helpers.toPromise(instance, callbackFunction);
+                const task = Helpers.toPromise(Promise, callback);
 
                 expect(task).to.be.instanceof(Promise);
                 expect(task.then).to.be.a.function();
@@ -318,19 +285,11 @@ describe('helpers', () => {
             });
         });
 
-        describe('bluebird', () => {
-
-            before((done) => {
-
-                instance.promise = Bluebird;
-                done();
-            });
+        describe('Bluebird Promise', () => {
 
             it('should promisify methods using the Bluebird implementation', (done) => {
 
-                expect(instance.promise).to.equal(Bluebird);
-
-                const task = Helpers.toPromise(instance, callbackFunction);
+                const task = Helpers.toPromise(Bluebird, callback);
 
                 expect(task).to.be.instanceof(Bluebird);
                 expect(task.then).to.be.a.function();

--- a/test/promise.js
+++ b/test/promise.js
@@ -1,0 +1,77 @@
+'use strict';
+
+const Code = require('code');
+const Lab = require('lab');
+const Bluebird = require('bluebird');
+const Q = require('q');
+
+const lab = exports.lab = Lab.script();
+const before = lab.before;
+const beforeEach = lab.beforeEach;
+const describe = lab.describe;
+const it = lab.it;
+const expect = Code.expect;
+
+const BunnyBus = require('../lib');
+let instance = undefined;
+
+describe('promise', () => {
+
+    before((done) => {
+
+        instance = new BunnyBus();
+        instance.config = BunnyBus.DEFAULT_SERVER_CONFIGURATION;
+        done();
+    });
+
+    it('should bootstrap with ES6 Promise', (done) => {
+
+        expect(instance.promise).to.equal(Promise);
+        done();
+    });
+
+    describe('custom promise', () => {
+
+        beforeEach((done) => {
+
+            instance.promise = Promise;
+            done();
+        });
+
+        it('should override with Bluebird', (done) => {
+
+            instance.promise = Bluebird;
+
+            expect(instance.promise).to.equal(Bluebird);
+            done();
+        });
+
+        it('should not override with Q', (done) => {
+
+            instance.promise = Q;
+
+            expect(instance.promise).to.equal(Promise);
+            done();
+        });
+
+        it('should override with Q when wrapped', (done) => {
+
+            class QWrap {
+
+                constructor(deferred) {
+
+                    const task = Q.defer();
+
+                    deferred(task.resolve, task.reject);
+
+                    return task.promise;
+                }
+            }
+
+            instance.promise = QWrap;
+
+            expect(instance.promise).to.equal(QWrap);
+            done();
+        });
+    });
+});


### PR DESCRIPTION
## Description
Refactored the interface for `Helpers.toPromise` so the Promise Framework was passed in directly as the first parameter in lieu of the `BunnyBus` instance reference.  I wanted the test of the `Helpers.toPromise` to isolate to itself + used parameters directly.  This helped separate the testing of the validation code path for valid Promise frameworks.  In doing so, the `validatePromiseContract` was also modified to provide for path shortcutting.  Other performance enhancements were done in `Helpers.toPromise` to remove extra variable declaration which should help with GC.

## Related Issue
- #2 

## Motivation and Context
Was a good time to refactor the code now that callback + promise code paths are side by side.

## Types of changes
- [ ] Documentation only (no changes to either `lib/` or `test/` files)
- [ ] Bug fix (non-breaking change which fixes an issue. you didn't modify existing tests)
- [ ] New feature (non-breaking change which adds functionality. you added at least one new test)
- [ ] Breaking change (fix or feature that would cause existing functionality to change. you had to modify existing tests.)

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/xogroup/bunnybus/blob/master/.github/CONTRIBUTING.md) document.
- [x] My code follows the [Hapi.js style guide](https://github.com/hapijs/contrib/blob/master/Style.md).
- [ ] I have updated the documentation as needed.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.