### PR TITLE
refactored subscription manager to use strong maps for state storage

### DIFF
--- a/lib/states/subscriptionManager.js
+++ b/lib/states/subscriptionManager.js
@@ -7,27 +7,31 @@ class SubscriptionManager extends EventEmitter {
     constructor() {
 
         super();
-        this._subscriptions = {};
+        this._subscriptions = new Map();
         this._blockQueues = new Set();
     }
 
     contains(queue, withConsumerTag = true) {
 
         if (withConsumerTag) {
-            return this._subscriptions.hasOwnProperty(queue) && this._subscriptions[queue].hasOwnProperty('consumerTag');
+            return this._subscriptions.has(queue) && this._subscriptions.get(queue).hasOwnProperty('consumerTag');
+            // return this._subscriptions.hasOwnProperty(queue) && this._subscriptions[queue].hasOwnProperty('consumerTag');
         }
 
-        return this._subscriptions.hasOwnProperty(queue);
+        return this._subscriptions.has(queue);
+        // return this._subscriptions.hasOwnProperty(queue);
     }
 
     create(queue, consumerTag, handlers, options) {
 
         if (this.contains(queue)) {
+            console.log('rejecting creation');
             return false;
         }
 
-        this._subscriptions[queue] = { consumerTag, handlers, options };
-        Helpers.cleanObject(this._subscriptions[queue]);
+        this._subscriptions.set(queue, { consumerTag, handlers, options });
+        // this._subscriptions[queue] = { consumerTag, handlers, options };
+        Helpers.cleanObject(this._subscriptions.get(queue));
         this.emit('subscription.created', this.get(queue));
 
         return true;
@@ -35,9 +39,9 @@ class SubscriptionManager extends EventEmitter {
 
     get(queue) {
 
-        if (this._subscriptions[queue]) {
+        if (this._subscriptions.has(queue)) {
             const clone = { queue };
-            Object.assign(clone, this._subscriptions[queue]);
+            Object.assign(clone, this._subscriptions.get(queue));
 
             return clone;
         }
@@ -48,7 +52,7 @@ class SubscriptionManager extends EventEmitter {
     clear(queue) {
 
         if (this.contains(queue)) {
-            delete this._subscriptions[queue].consumerTag;
+            delete this._subscriptions.get(queue).consumerTag;
             this.emit('subscription.cleared', this.get(queue));
 
             return true;
@@ -61,7 +65,7 @@ class SubscriptionManager extends EventEmitter {
 
         if (this.contains(queue, false)) {
             this.emit('subscription.removed', this.get(queue));
-            delete this._subscriptions[queue];
+            delete this._subscriptions.delete(queue);
 
             return true;
         }
@@ -73,11 +77,16 @@ class SubscriptionManager extends EventEmitter {
 
         const results = [];
 
-        for (const queue in this._subscriptions) {
+        for (const [queue, subscription] of this._subscriptions) {
             const copy = { queue };
-            Object.assign(copy, this._subscriptions[queue]);
+            Object.assign(copy, subscription);
             results.push(copy);
         }
+        // for (const queue in this._subscriptions) {
+        //     const copy = { queue };
+        //     Object.assign(copy, this._subscriptions[queue]);
+        //     results.push(copy);
+        // }
 
         return results;
     }

--- a/test/states.js
+++ b/test/states.js
@@ -25,10 +25,12 @@ describe('state management', () => {
 
         beforeEach((done) => {
 
-            if (instance && instance._subscriptions) {
-                for (const key in instance._subscriptions) {
-                    delete instance._subscriptions[key];
-                }
+            if (instance) {
+
+                instance._subscriptions.clear();
+                // for (const key in instance._subscriptions) {
+                //     delete instance._subscriptions[key];
+                // }
 
                 instance._blockQueues.clear();
             }
@@ -48,7 +50,7 @@ describe('state management', () => {
                 const options = {};
 
                 const response = instance.create(queueName, consumerTag, handlers, options);
-                const sut = instance._subscriptions[queueName];
+                const sut = instance._subscriptions.get(queueName);
 
                 expect(response).to.be.true();
                 expect(sut).to.exist();
@@ -139,7 +141,7 @@ describe('state management', () => {
 
                 instance.create(queueName, consumerTag, handlers, options);
                 const response = instance.clear(queueName);
-                const sut = instance._subscriptions[queueName].hasOwnProperty('consumerTag');
+                const sut = instance._subscriptions.get(queueName).hasOwnProperty('consumerTag');
 
                 expect(response).to.be.true();
                 expect(sut).to.be.false();
@@ -154,7 +156,7 @@ describe('state management', () => {
                 const options = {};
 
                 instance.create(queueName, consumerTag, handlers, options);
-                delete instance._subscriptions[queueName].consumerTag;
+                delete instance._subscriptions.get(queueName).consumerTag;
                 const response = instance.clear(queueName);
 
                 expect(response).to.be.false();
@@ -225,7 +227,7 @@ describe('state management', () => {
                 const options = {};
 
                 instance.create(queueName, consumerTag, handlers, options);
-                delete instance._subscriptions[queueName].consumerTag;
+                delete instance._subscriptions.get(queueName).consumerTag;
                 const response = instance.contains(queueName, false);
 
                 expect(response).to.be.true();
@@ -269,7 +271,7 @@ describe('state management', () => {
                 const options = {};
 
                 instance.create(queueName, consumerTag, handlers, options);
-                delete instance._subscriptions[queueName].consumerTag;
+                delete instance._subscriptions.get(queueName).consumerTag;
                 const response = instance.remove(queueName);
 
                 expect(response).to.be.true();


### PR DESCRIPTION
## Description
Refactored Subscription Manager to use `Map` for internal storage.  We want to leverage ES6 features where available and appropriate.

## Related Issue
#2 

## Motivation and Context
To stop abusing the use of object hash for key/value storage.

## Types of changes
- [ ] Documentation only (no changes to either `lib/` or `test/` files)
- [x] Bug fix (non-breaking change which fixes an issue. you didn't modify existing tests)
- [ ] New feature (non-breaking change which adds functionality. you added at least one new test)
- [ ] Breaking change (fix or feature that would cause existing functionality to change. you had to modify existing tests.)

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/xogroup/bunnybus/blob/master/.github/CONTRIBUTING.md) document.
- [x] My code follows the [Hapi.js style guide](https://github.com/hapijs/contrib/blob/master/Style.md).
- [ ] I have updated the documentation as needed.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.