### PR TITLE
refactored code and test to support polymorphic payload type

### DIFF
--- a/API.md
+++ b/API.md
@@ -398,7 +398,7 @@ A `key` is the routeKey in RabbitMQ terminology.  `BunnyBus` specifically levera
 ##### `handler`
 
 A `handler` is a function which contains the following arity.  Order matters.
-  - `message` is what was received from the bus.  The message is a JS object and not the buffer.  The original source of this object is from `payload.content`.
+  - `message` is what was received from the bus.  The message does represent the RabbitMQ `'payload.content` buffer.  The original source of this object is from `payload.content`.
   - `ack([option, [callback]])` is a function for acknowledging the message off the bus.
     - `option` - a placeholder for future optional parameters for `ack`.  High chance of deprecation.
     - `callback` - node style callback `(err, result) => {}`. *[Function]* **Optional**
@@ -501,7 +501,7 @@ bunnyBus.send(message, 'queue1')
 
 ####`get(queue, [options, [callback]])`
 
-Pop a message directly off a queue.
+Pop a message directly off a queue.  The payload returned is the RabbitMQ `payload` with `payload.properties` and `payload.content` in its original form.
 
 #####parameter(s)
 

--- a/lib/helpers/convertToBuffer.js
+++ b/lib/helpers/convertToBuffer.js
@@ -4,12 +4,16 @@ const convertToBuffer = (content, callback) => {
 
     setImmediate(() => {
 
-        if (Buffer.isBuffer(content)) {
-            callback(null, content);
+        const result = {
+            isBuffer : Buffer.isBuffer(content),
+            buffer : content
+        };
+
+        if (!result.isBuffer) {
+            result.buffer = new Buffer(JSON.stringify(content));
         }
-        else {
-            callback(null, new Buffer(JSON.stringify(content)));
-        }
+
+        callback(null, result);
     });
 };
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -333,12 +333,13 @@ class BunnyBus extends EventEmitter{
                 const sendOptions = {
                     headers : {
                         transactionId : results.create_transaction_id,
+                        isBuffer      : results.convert_message.buffer.isBuffer,
                         callingModule,
                         createdAt     : (new Date()).toISOString()
                     }
                 };
 
-                $.channel.sendToQueue(queue, results.convert_message, sendOptions, cb);
+                $.channel.sendToQueue(queue, results.convert_message.buffer, sendOptions, cb);
             }],
             wait                 : ['send', (results, cb) => {
 
@@ -400,13 +401,14 @@ class BunnyBus extends EventEmitter{
                 const publishOptions = {
                     headers: {
                         transactionId : results.create_transaction_id,
+                        isBuffer      : results.convert_message.isBuffer,
                         callingModule,
                         routeKey,
                         createdAt     : (new Date()).toISOString()
                     }
                 };
 
-                $.channel.publish(globalExchange, routeKey, results.convert_message, publishOptions, cb);
+                $.channel.publish(globalExchange, routeKey, results.convert_message.buffer, publishOptions, cb);
             }],
             wait                  : ['publish', (results, cb) => {
 
@@ -470,7 +472,7 @@ class BunnyBus extends EventEmitter{
                     queue,
                     (payload) => {
 
-                        const message = JSON.parse(payload.content.toString());
+                        const message = payload.properties.headers.isBuffer ? payload.content : JSON.parse(payload.content.toString());
                         const routeKey = payload.properties.headers.routeKey || message.event || payload.fields.routingKey;
                         const currentRetryCount = payload.properties.headers.retryCount || -1;
                         const errorQueue = `${queue}_error`;
@@ -578,6 +580,7 @@ class BunnyBus extends EventEmitter{
             const sendOptions = {
                 headers : {
                     transactionId : payload.properties.headers.transactionId,
+                    isBuffer      : payload.properties.headers.isBuffer,
                     callingModule : payload.properties.headers.callingModule,
                     createAt      : payload.properties.headers.createdAt,
                     requeuedAt    : (new Date()).toISOString(),
@@ -616,6 +619,7 @@ class BunnyBus extends EventEmitter{
             const sendOptions = {
                 headers : {
                     transactionId : payload.properties.headers.transactionId,
+                    isBuffer      : payload.properties.headers.isBuffer,
                     callingModule : payload.properties.headers.callingModule,
                     createAt      : payload.properties.headers.createdAt,
                     requeuedAt    : payload.properties.headers.requeuedAt,

--- a/test/assertions/assertConvertToBuffer.js
+++ b/test/assertions/assertConvertToBuffer.js
@@ -9,13 +9,15 @@ const assertConvertToBuffer = (data, callback) => {
     Helpers.convertToBuffer(data, (err, result) => {
 
         expect(err).to.be.null();
-        expect(result).to.be.a.instanceof(Buffer);
+        expect(result.buffer).to.be.a.instanceof(Buffer);
 
         if (Buffer.isBuffer(data)) {
-            expect(Buffer.compare(result, data)).to.equal(0);
+            expect(Buffer.compare(result.buffer, data)).to.equal(0);
+            expect(result.isBuffer).to.be.true();
         }
         else {
-            expect(JSON.parse(result.toString())).to.equal(data);
+            expect(JSON.parse(result.buffer.toString())).to.equal(data);
+            expect(result.isBuffer).to.be.false();
         }
 
         callback();


### PR DESCRIPTION
## Description
- Added support for polymorphic payload handling for different data types.  For example, publishing a message of type Object will be subscribed back as type Object.  While sending a message of type Buffer will be subscribed back as type Buffer.
- Updated documentation around `get()` and `publish()` to highlight this feature.
- Updated `Helpers.convertMessage()` to return a complex object to store the original state of the input.

## Related Issue
- #2 

## Motivation and Context
Wanted to add test to make sure this test was supported.  Found that implementation did not satisfy desire within the documentation.

## Types of changes
- [ ] Documentation only (no changes to either `lib/` or `test/` files)
- [x] Bug fix (non-breaking change which fixes an issue. you didn't modify existing tests)
- [ ] New feature (non-breaking change which adds functionality. you added at least one new test)
- [ ] Breaking change (fix or feature that would cause existing functionality to change. you had to modify existing tests.)

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/xogroup/bunnybus/blob/master/.github/CONTRIBUTING.md) document.
- [x] My code follows the [Hapi.js style guide](https://github.com/hapijs/contrib/blob/master/Style.md).
- [x] I have updated the documentation as needed.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.