### PR TITLE
WIP: TODO with connection recovery path and fixing edge case sceanrios

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -7,34 +7,13 @@ const Helpers = require('./helpers');
 const Exceptions = require('./exceptions');
 const SubscriptionManager = require('./states').SubscriptionManager;
 const EventLogger = require('./loggers').EventLogger;
+const AMQP_CONNECTION_ERROR_EVENT = 'error';
+const AMQP_CHANNEL_ERROR_EVENT = 'error';
 const internals = {
     handlers : {}
 };
 
 let $ = undefined;
-
-// TODO create supporting test for these.
-internals.handlers[SubscriptionManager.BLOCKED_EVENT] = (queue) => {
-
-    $.unsubscribe(queue, (err) => {
-
-        if (err) {
-            $.logger.error(err);
-        }
-    });
-};
-
-internals.handlers[SubscriptionManager.UNBLOCKED_EVENT] = (queue) => {
-
-    const subscription = $._subscriptions.get(queue);
-
-    $.subscribe(queue, subscription.handlers, subscription.options, (err) => {
-
-        if (err) {
-            $.logger.error(err);
-        }
-    });
-};
 
 class BunnyBus extends EventEmitter{
 
@@ -121,6 +100,26 @@ class BunnyBus extends EventEmitter{
         return 'bunnybus.unsubscribed';
     }
 
+    static get RECOVERING_EVENT() {
+
+        return 'bunnybus.recovering';
+    }
+
+    static get RECOVERED_EVENT() {
+
+        return 'bunnybus.recovered';
+    }
+
+    static get AMQP_CONNECTION_ERROR_EVENT() {
+
+        return 'amqp.connection.error';
+    }
+
+    static get AMQP_CHANNEL_ERROR_EVENT() {
+
+        return 'amqp.channel.error';
+    }
+
     get config() {
 
         return $._config || BunnyBus.DEFAULT_SERVER_CONFIGURATION;
@@ -173,7 +172,7 @@ class BunnyBus extends EventEmitter{
     set connection(value) {
 
         if (value) {
-            value.on('error', $._recoverConnectChannel);
+            value.on(AMQP_CONNECTION_ERROR_EVENT, internals.handlers[BunnyBus.AMQP_CONNECTION_ERROR_EVENT]);
         }
 
         $._connection = value;
@@ -192,7 +191,7 @@ class BunnyBus extends EventEmitter{
     set channel(value) {
 
         if (value) {
-            value.on('error', $._recoverConnectChannel);
+            value.on(AMQP_CHANNEL_ERROR_EVENT, internals.handlers[BunnyBus.AMQP_CHANNEL_ERROR_EVENT]);
         }
 
         $._channel = value;
@@ -248,8 +247,6 @@ class BunnyBus extends EventEmitter{
             callback(new Exceptions.NoChannelError());
         }
         else {
-            //TODO, callback needs to be proxied so we can down the channel when this comes back negative.
-            //Also test needs to be added for this.
             $.channel.checkExchange(name, callback);
         }
     }
@@ -645,7 +642,7 @@ class BunnyBus extends EventEmitter{
             return Helpers.toPromise($.promise, $._autoConnectChannel);
         }
 
-        if ($.hasConnection || $.hasChannel) {
+        if ($.hasConnection && $.hasChannel) {
             callback();
         }
         else {
@@ -660,19 +657,13 @@ class BunnyBus extends EventEmitter{
 
         $._state.recovery = true;
 
-        //TODO need to check to see if retry executes immediately.
-        //Retry 240 times every 15 seconds if there is a connection problem.
-        //If after 1 hour the issue does not resolve, kill the process.
+        $.emit(BunnyBus.RECOVERING_EVENT);
+
         Async.retry({
             times   : 240,
             interval: 15000
-        }, (cb) => {
-
-            Async.waterfall([
-                $._closeConnection,
-                $._autoConnectChannel
-            ], cb);
         },
+        (cb) => $._autoConnectChannel(cb),
         (err) => {
 
             if (err) {
@@ -680,11 +671,12 @@ class BunnyBus extends EventEmitter{
             }
             else {
                 $._state.recovery = false;
+                $.emit(BunnyBus.RECOVERED_EVENT);
             }
         });
     }
 
-    _createConnection(callback) {
+    _createConnection(callback)  {
 
         callback = Helpers.reduceCallback(callback);
 
@@ -735,7 +727,6 @@ class BunnyBus extends EventEmitter{
         ], (err) => {
 
             if (!err) {
-
                 $.connection = null;
             }
 
@@ -805,5 +796,42 @@ class BunnyBus extends EventEmitter{
         }
     }
 }
+
+internals.handlers[SubscriptionManager.BLOCKED_EVENT] = (queue) => {
+
+    $.unsubscribe(queue, (err) => {
+
+        if (err) {
+            $.logger.error(err);
+        }
+    });
+};
+
+internals.handlers[SubscriptionManager.UNBLOCKED_EVENT] = (queue) => {
+
+    const subscription = $._subscriptions.get(queue);
+
+    $.subscribe(queue, subscription.handlers, subscription.options, (err) => {
+
+        if (err) {
+            $.logger.error(err);
+        }
+    });
+};
+
+internals.handlers[BunnyBus.AMQP_CONNECTION_ERROR_EVENT] = (err) => {
+
+    $.emit(BunnyBus.AMQP_CONNECTION_ERROR_EVENT, err);
+    $.connection = null;
+    $.channel = null;
+    $._recoverConnectChannel();
+};
+
+internals.handlers[BunnyBus.AMQP_CHANNEL_ERROR_EVENT] = (err) => {
+
+    $.emit(BunnyBus.AMQP_CHANNEL_ERROR_EVENT, err);
+    $.channel = null;
+    $._recoverConnectChannel();
+};
 
 module.exports = BunnyBus;

--- a/test/integration-callback.js
+++ b/test/integration-callback.js
@@ -172,7 +172,7 @@ describe('positive integration tests - Callback api', () => {
                 expect(instance.connection).to.exist();
                 expect(instance.channel).to.exist();
                 done();
-            }, 100);
+            }, 50);
         });
 
         it('should recreate connection when channel error occurs', (done) => {
@@ -184,7 +184,7 @@ describe('positive integration tests - Callback api', () => {
                 expect(instance.connection).to.exist();
                 expect(instance.channel).to.exist();
                 done();
-            }, 100);
+            }, 50);
         });
     });
 
@@ -276,6 +276,13 @@ describe('positive integration tests - Callback api', () => {
                 expect(err).to.be.null();
                 done();
             });
+        });
+
+        it('should recover from a non existent exchange', (done) => {
+
+            instance.once(BunnyBus.RECOVERED_EVENT, done);
+
+            instance.checkExchange(exchangeName, () => {});
         });
     });
 

--- a/test/integration-events.js
+++ b/test/integration-events.js
@@ -26,6 +26,36 @@ describe('positive integration tests - events', () => {
         done();
     });
 
+    describe('recovering', () =>  {
+
+        before((done) => {
+
+            instance._autoConnectChannel(done);
+        });
+
+        it('should be evented when connection is recovering', (done) => {
+
+            instance.once(BunnyBus.RECOVERING_EVENT, done);
+
+            instance.connection.emit('error');
+        });
+    });
+
+    describe('recovered', () => {
+
+        before((done) => {
+
+            instance._autoConnectChannel(done);
+        });
+
+        it('should be evented when connection is recovering', (done) => {
+
+            instance.once(BunnyBus.RECOVERED_EVENT, done);
+
+            instance.connection.emit('error');
+        });
+    });
+
     describe('published', () => {
 
         const message = { event : 'published-event', name : 'bunnybus' };


### PR DESCRIPTION
## Description
Working on clearing up TODO's.  

This work embodies the fix around corrupted connection and channels and the recovery of said channel when the causation was created organically through something like `checkExchange()` command where the exchange does not exist.

## Related Issue
- #2

## Types of changes
- [x] Documentation only (no changes to either `lib/` or `test/` files)
- [x] Bug fix (non-breaking change which fixes an issue. you didn't modify existing tests)
- [x] New feature (non-breaking change which adds functionality. you added at least one new test)
- [ ] Breaking change (fix or feature that would cause existing functionality to change. you had to modify existing tests.)

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/xogroup/bunnybus/blob/master/.github/CONTRIBUTING.md) document.
- [x] My code follows the [Hapi.js style guide](https://github.com/hapijs/contrib/blob/master/Style.md).
- [x] I have updated the documentation as needed.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.