### PR TITLE
Fixed Subscribe call with blocked queues

### DIFF
--- a/API.md
+++ b/API.md
@@ -361,7 +361,7 @@ Publish a message onto the bus.
   - `options` - optional settings. *[Object]* **Optional**
     - `routeKey` - value for the route key to route the message with.  The value must be supplied here or in `message.event`.  The value can be `.` separated for namespacing. *[string]*  **Optional**
     - `transactionId` - value attached to the header of the message for tracing.  When one is not supplied, a random 40 character token is generated. *[string]*  **Optional**
-    - `callingModule` - value attached to the header of the message to help with tracking the origination point of your application.  For applications that leverage this plugin in multiple modules, each module can supply its own module name so a message can be tracked to the creator. *[string]* 
+    - `source` - value attached to the header of the message to help with tracking the origination point of your application.  For applications that leverage this plugin in multiple modules, each module can supply its own module name so a message can be tracked to the creator. *[string]* 
  **Optional**
     - `globalExchange` - value to override the exchange specified in `config`. *[string]* **Optional**
   - `callback` - node style callback `(err, result) => {}`. *[Function]* **Optional**
@@ -486,7 +486,7 @@ Send a message directly to a queue.
   - `queue` - the name of the queue. *[string]* **Required**
   - `options` - optional settings. *[Object]* **Optional**
     - `transactionId` - value attached to the header of the message for tracing.  When one is not supplied, a random 40 character token is generated. *[string]*  **Optional**
-    - `callingModule` - value attached to the header of the message to help with tracking the origination point of your application.  For applications that leverage this plugin in multiple modules, each module can supply its own module name so a message can be tracked to the creator. *[string]*  **Optional**
+    - `source` - value attached to the header of the message to help with tracking the origination point of your application.  For applications that leverage this plugin in multiple modules, each module can supply its own module name so a message can be tracked to the creator. *[string]*  **Optional**
   - `callback` - node style callback `(err, result) => {}`. *[Function]* **Optional**
 
 ```Javascript

--- a/API.md
+++ b/API.md
@@ -47,6 +47,7 @@
   - [`SubscriptionManager`](#subscriptionmanager)
     - [`contains(queue, [withConsumerTag])`](#containsqueue-withconsumertag)
     - [`create(queue, [consumerTag, [handlers, [options]]])`](#createqueue-consumertag-handlers-options)
+    - [`tag(queue, consumerTag)`](#tagqueue-consumertag)
     - [`get(queue)`](#getqueue)
     - [`clear(queue)`](#clearqueue)
     - [`remove(queue)`](#removequeue)
@@ -865,13 +866,12 @@ const message = {
 }
 ```
 
-###`create(queue, [consumerTag, [handlers, [options]]])`
+###`create(queue, handlers, [options])`
 
 Creates a subscription.
 
 * `queue` - the name of the queue. *[string]* **Required**
-* `consumerTag` - a value returned from the [`consume()`](http://www.squaremobius.net/amqp.node/channel_api.html#channel_consume) method of amqplib.  *[string]* **Optional**
-* `handlers` - handlers parameter passed through the [`subscribe()`](#subscribequeue-handlers-options-callback) method.  *[Object]* **Optional**
+* `handlers` - handlers parameter passed through the [`subscribe()`](#subscribequeue-handlers-options-callback) method.  *[Object]* **Required**
 * `options` - options parameter passed through the [`subscribe()`](#subscribequeue-handlers-options-callback) method.  *[Object]* **Optional**
 
 ```Javascript
@@ -879,6 +879,21 @@ const BunnyBus = require('bunnybus');
 const bunnyBus = new BunnyBus();
 
 bunnybus.subscriptions.create('queue1');
+}
+```
+
+###`tag(queue, consumerTag)`
+
+Tag a subscription.
+
+* `queue` - the name of the queue. *[string]* **Required**
+* `consumerTag` - a value returned from the [`consume()`](http://www.squaremobius.net/amqp.node/channel_api.html#channel_consume) method of amqplib.  *[string]* **Required**
+
+```Javascript
+const BunnyBus = require('bunnybus');
+const bunnyBus = new BunnyBus();
+
+bunnybus.subscriptions.tag('queue1', 'abcd1234');
 }
 ```
 

--- a/API.md
+++ b/API.md
@@ -46,7 +46,7 @@
     - [`BunnyBus.AMQP_CHANNEL_ERROR_EVENT`](#bunnybusamqp_channel_error_event)   
   - [`SubscriptionManager`](#subscriptionmanager)
     - [`contains(queue, [withConsumerTag])`](#containsqueue-withconsumertag)
-    - [`create(queue, [consumerTag, [handlers, [options]]])`](#createqueue-consumertag-handlers-options)
+    - [`create(queue, handlers, [options])`](#createqueue--handlers-options)
     - [`tag(queue, consumerTag)`](#tagqueue-consumertag)
     - [`get(queue)`](#getqueue)
     - [`clear(queue)`](#clearqueue)

--- a/lib/exceptions/index.js
+++ b/lib/exceptions/index.js
@@ -1,8 +1,9 @@
 'use strict';
 
 module.exports = {
-    NoConnectionError      : require('./noConnectionError'),
-    NoChannelError         : require('./noChannelError'),
-    NoRouteKeyError        : require('./noRouteKeyError'),
-    SubscriptionExistError : require('./subscriptionExistError')
+    NoConnectionError       : require('./noConnectionError'),
+    NoChannelError          : require('./noChannelError'),
+    NoRouteKeyError         : require('./noRouteKeyError'),
+    SubscriptionExistError  : require('./subscriptionExistError'),
+    SubscriptionBlockedError: require('./subscriptionBlockedError')
 };

--- a/lib/exceptions/subscriptionBlockedError.js
+++ b/lib/exceptions/subscriptionBlockedError.js
@@ -1,0 +1,12 @@
+'use strict';
+
+class SubscriptionBlockedError extends Error {
+
+    constructor(queue, message) {
+
+        super(message || `subscription blocked for queue of name ${queue}`);
+        this.name = 'SubscriptionBlockedError';
+    }
+}
+
+module.exports = SubscriptionBlockedError;

--- a/lib/index.js
+++ b/lib/index.js
@@ -309,8 +309,7 @@ class BunnyBus extends EventEmitter{
             return Helpers.toPromise($.promise, $.send, message, queue, options);
         }
 
-        //TODO rename callingModule to source
-        const callingModule = (options && options.callingModule);
+        const source = (options && options.source);
 
         Async.auto({
             initialize           : (cb) => $._autoConnectChannel(cb),
@@ -331,7 +330,7 @@ class BunnyBus extends EventEmitter{
                     headers : {
                         transactionId : results.create_transaction_id,
                         isBuffer      : results.convert_message.buffer.isBuffer,
-                        callingModule,
+                        source,
                         createdAt     : (new Date()).toISOString()
                     }
                 };
@@ -371,8 +370,8 @@ class BunnyBus extends EventEmitter{
 
         const globalExchange = (options && options.globalExchange) || $.config.globalExchange;
         const routeKey = (options && options.routeKey) || (message && message.event);
-        //rename callingModule to source
-        const callingModule = (options && options.callingModule);
+        //rename source to source
+        const source = (options && options.source);
 
         if (!routeKey) {
             callback(new Exceptions.NoRouteKeyError());
@@ -399,7 +398,7 @@ class BunnyBus extends EventEmitter{
                     headers: {
                         transactionId : results.create_transaction_id,
                         isBuffer      : results.convert_message.isBuffer,
-                        callingModule,
+                        source,
                         routeKey,
                         createdAt     : (new Date()).toISOString()
                     }
@@ -578,7 +577,7 @@ class BunnyBus extends EventEmitter{
                 headers : {
                     transactionId : payload.properties.headers.transactionId,
                     isBuffer      : payload.properties.headers.isBuffer,
-                    callingModule : payload.properties.headers.callingModule,
+                    source : payload.properties.headers.source,
                     createAt      : payload.properties.headers.createdAt,
                     requeuedAt    : (new Date()).toISOString(),
                     retryCount    : payload.properties.headers.retryCount || 0,
@@ -617,7 +616,7 @@ class BunnyBus extends EventEmitter{
                 headers : {
                     transactionId : payload.properties.headers.transactionId,
                     isBuffer      : payload.properties.headers.isBuffer,
-                    callingModule : payload.properties.headers.callingModule,
+                    source : payload.properties.headers.source,
                     createAt      : payload.properties.headers.createdAt,
                     requeuedAt    : payload.properties.headers.requeuedAt,
                     errorAt       : (new Date()).toISOString(),

--- a/lib/index.js
+++ b/lib/index.js
@@ -436,11 +436,11 @@ class BunnyBus extends EventEmitter{
         const $S = $.subscriptions;
 
         if ($S.contains(queue)) {
-            callback(new Exceptions.SubscriptionExistError(null, queue));
+            callback(new Exceptions.SubscriptionExistError(queue));
             return;
         }
 
-        $S.create(queue);
+        $S.create(queue, handlers, options);
 
         const queueOptions = options && options.queue ? options.queue : null;
         const globalExchange = (options && options.globalExchange) || $.config.globalExchange;
@@ -464,6 +464,10 @@ class BunnyBus extends EventEmitter{
                 );
             }],
             setup_consumer : ['create_queue', (results, cb) => {
+
+                if ($S.isBlocked(queue)) {
+                    return cb(new Exceptions.SubscriptionBlockedError(queue));
+                }
 
                 $.channel.consume(
                     queue,
@@ -492,15 +496,11 @@ class BunnyBus extends EventEmitter{
                         else {
                             $.channel.ack(payload);
                         }
-                        //TODO
-                        //* collect consume tag info so we can pause/cancel subscription
-                        // save the handlers + options in a state to resume cancelled subscriptions
-                        //* validate message format
                     },
                     null,
                     (err, result) => {
 
-                        $S.create(queue, result.consumerTag, handlers, options);
+                        $S.tag(queue, result.consumerTag);
 
                         cb(err);
                     });

--- a/lib/states/subscriptionManager.js
+++ b/lib/states/subscriptionManager.js
@@ -16,6 +16,11 @@ class SubscriptionManager extends EventEmitter {
         return 'subscription.created';
     }
 
+    static get TAGGED_EVENT() {
+
+        return 'subscription.tagged';
+    }
+
     static get CLEARED_EVENT() {
 
         return 'subscription.cleared';
@@ -45,15 +50,27 @@ class SubscriptionManager extends EventEmitter {
         return this._subscriptions.has(queue);
     }
 
-    create(queue, consumerTag, handlers, options) {
+    create(queue, handlers, options) {
 
-        if (this.contains(queue)) {
+        if (this.contains(queue, false)) {
             return false;
         }
 
-        this._subscriptions.set(queue, { consumerTag, handlers, options });
+        this._subscriptions.set(queue, { handlers, options });
         Helpers.cleanObject(this._subscriptions.get(queue));
         this.emit(SubscriptionManager.CREATED_EVENT, this.get(queue));
+
+        return true;
+    }
+
+    tag(queue, consumerTag) {
+
+        if (!this.contains(queue, false)) {
+            return false;
+        }
+
+        Object.assign(this._subscriptions.get(queue), { consumerTag });
+        this.emit(SubscriptionManager.TAGGED_EVENT, this.get(queue));
 
         return true;
     }
@@ -105,6 +122,11 @@ class SubscriptionManager extends EventEmitter {
         }
 
         return results;
+    }
+
+    isBlocked(queue) {
+
+        return this._blockQueues.has(queue);
     }
 
     block(queue) {

--- a/test/assertions/assertPublish.js
+++ b/test/assertions/assertPublish.js
@@ -4,12 +4,12 @@ const Async = require('async');
 const Code = require('code');
 const expect = Code.expect;
 
-const assertPublish = (instance, message, queueName, routeKey, transactionId, callingModule, shouldRoute, callback) => {
+const assertPublish = (instance, message, queueName, routeKey, transactionId, source, shouldRoute, callback) => {
 
     const options = {
         routeKey,
         transactionId,
-        callingModule
+        source
     };
 
     Async.waterfall([
@@ -32,16 +32,16 @@ const assertPublish = (instance, message, queueName, routeKey, transactionId, ca
                 expect(payload.properties.headers.routeKey).to.equal(message.event);
             }
 
-            if (callingModule) {
-                expect(payload.properties.headers.callingModule).to.be.string();
+            if (source) {
+                expect(payload.properties.headers.source).to.be.string();
             }
 
             if (transactionId) {
                 expect(payload.properties.headers.transactionId).to.equal(transactionId);
             }
 
-            if (callingModule) {
-                expect(payload.properties.headers.callingModule).to.equal(callingModule);
+            if (source) {
+                expect(payload.properties.headers.source).to.equal(source);
             }
 
             instance.channel.ack(payload);

--- a/test/assertions/assertPublishPromise.js
+++ b/test/assertions/assertPublishPromise.js
@@ -3,12 +3,12 @@
 const Code = require('code');
 const expect = Code.expect;
 
-const assertPublishPromise = (instance, message, queueName, routeKey, transactionId, callingModule, shouldRoute) => {
+const assertPublishPromise = (instance, message, queueName, routeKey, transactionId, source, shouldRoute) => {
 
     const options = {
         routeKey,
         transactionId,
-        callingModule
+        source
     };
 
     return instance.publish(message, options)
@@ -32,16 +32,16 @@ const assertPublishPromise = (instance, message, queueName, routeKey, transactio
                     expect(payload.properties.headers.routeKey).to.equal(message.event);
                 }
 
-                if (callingModule) {
-                    expect(payload.properties.headers.callingModule).to.be.string();
+                if (source) {
+                    expect(payload.properties.headers.source).to.be.string();
                 }
 
                 if (transactionId) {
                     expect(payload.properties.headers.transactionId).to.equal(transactionId);
                 }
 
-                if (callingModule) {
-                    expect(payload.properties.headers.callingModule).to.equal(callingModule);
+                if (source) {
+                    expect(payload.properties.headers.source).to.equal(source);
                 }
 
                 instance.channel.ack(payload);

--- a/test/assertions/assertSend.js
+++ b/test/assertions/assertSend.js
@@ -4,11 +4,11 @@ const Async = require('async');
 const Code = require('code');
 const expect = Code.expect;
 
-const assertSend = (instance, message, queueName, transactionId, callingModule, callback) => {
+const assertSend = (instance, message, queueName, transactionId, source, callback) => {
 
     const options = {
         transactionId,
-        callingModule
+        source
     };
 
     Async.waterfall([
@@ -23,16 +23,16 @@ const assertSend = (instance, message, queueName, transactionId, callingModule, 
         expect(payload.properties.headers.transactionId).to.be.string();
         expect(payload.properties.headers.createdAt).to.exist();
 
-        if (callingModule) {
-            expect(payload.properties.headers.callingModule).to.be.string();
+        if (source) {
+            expect(payload.properties.headers.source).to.be.string();
         }
 
         if (transactionId) {
             expect(payload.properties.headers.transactionId).to.equal(transactionId);
         }
 
-        if (callingModule) {
-            expect(payload.properties.headers.callingModule).to.equal(callingModule);
+        if (source) {
+            expect(payload.properties.headers.source).to.equal(source);
         }
 
         instance.channel.ack(payload);

--- a/test/assertions/assertSendPromise.js
+++ b/test/assertions/assertSendPromise.js
@@ -3,11 +3,11 @@
 const Code = require('code');
 const expect = Code.expect;
 
-const assertSendPromise = (instance, message, queueName, transactionId, callingModule) => {
+const assertSendPromise = (instance, message, queueName, transactionId, source) => {
 
     const options = {
         transactionId,
-        callingModule
+        source
     };
 
     return instance.send(message, queueName, options)
@@ -23,16 +23,16 @@ const assertSendPromise = (instance, message, queueName, transactionId, callingM
             expect(payload.properties.headers.transactionId).to.be.string();
             expect(payload.properties.headers.createdAt).to.exist();
 
-            if (callingModule) {
-                expect(payload.properties.headers.callingModule).to.be.string();
+            if (source) {
+                expect(payload.properties.headers.source).to.be.string();
             }
 
             if (transactionId) {
                 expect(payload.properties.headers.transactionId).to.equal(transactionId);
             }
 
-            if (callingModule) {
-                expect(payload.properties.headers.callingModule).to.equal(callingModule);
+            if (source) {
+                expect(payload.properties.headers.source).to.equal(source);
             }
 
             return instance.channel.ack(payload);

--- a/test/integration-callback.js
+++ b/test/integration-callback.js
@@ -306,7 +306,7 @@ describe('positive integration tests - Callback api', () => {
             Assertions.assertSend(instance, message, queueName, null, null, done);
         });
 
-        it('should proxy `callingModule` when supplied', (done) => {
+        it('should proxy `source` when supplied', (done) => {
 
             Assertions.assertSend(instance, message, queueName, null, 'someModule', done);
         });
@@ -381,7 +381,7 @@ describe('positive integration tests - Callback api', () => {
             Assertions.assertPublish(instance, message, queueName, 'z', null, null, false, done);
         });
 
-        it('should proxy `callingModule` when supplied', (done) => {
+        it('should proxy `source` when supplied', (done) => {
 
             Assertions.assertPublish(instance, message, queueName, 'a', null, 'someModule', true, done);
         });
@@ -804,7 +804,7 @@ describe('positive integration tests - Callback api', () => {
         it('should requeue with well formed header properties', (done) => {
 
             const publishOptions = {
-                callingModule : 'test'
+                source : 'test'
             };
 
             let transactionId = null;
@@ -825,7 +825,7 @@ describe('positive integration tests - Callback api', () => {
                 expect(err).to.be.null();
                 expect(payload.properties.headers.transactionId).to.equal(transactionId);
                 expect(payload.properties.headers.createAt).to.equal(createdAt);
-                expect(payload.properties.headers.callingModule).to.equal(publishOptions.callingModule);
+                expect(payload.properties.headers.source).to.equal(publishOptions.source);
                 expect(payload.properties.headers.requeuedAt).to.exist();
                 expect(payload.properties.headers.retryCount).to.equal(1);
                 done();
@@ -900,7 +900,7 @@ describe('positive integration tests - Callback api', () => {
         it('should requeue with well formed header properties', (done) => {
 
             const publishOptions = {
-                callingModule : 'test'
+                source : 'test'
             };
             const requeuedAt = (new Date()).toISOString();
             const retryCount = 5;
@@ -924,7 +924,7 @@ describe('positive integration tests - Callback api', () => {
                 expect(err).to.be.null();
                 expect(payload.properties.headers.transactionId).to.equal(transactionId);
                 expect(payload.properties.headers.createAt).to.equal(createdAt);
-                expect(payload.properties.headers.callingModule).to.equal(publishOptions.callingModule);
+                expect(payload.properties.headers.source).to.equal(publishOptions.source);
                 expect(payload.properties.headers.requeuedAt).to.equal(requeuedAt);
                 expect(payload.properties.headers.retryCount).to.equal(retryCount);
                 expect(payload.properties.headers.errorAt).to.exist();

--- a/test/integration-callback.js
+++ b/test/integration-callback.js
@@ -1067,6 +1067,43 @@ describe('negative integration tests', () => {
         });
     });
 
+    describe('subscribe', () => {
+
+        const queueName = 'test-queue-1';
+        const consumerTag = 'abcde12345';
+        const handlers = { event1 : () => {} };
+
+        afterEach((done) => {
+
+            instance.subscriptions._subscriptions.clear();
+            instance.subscriptions._blockQueues.clear();
+            done();
+        });
+
+        it('should throw SubscriptionExistError when calling subscribe on an active subscription exist', (done) => {
+
+            instance.subscriptions.create(queueName, handlers);
+            instance.subscriptions.tag(queueName, consumerTag);
+
+            instance.subscribe(queueName, handlers, (err) => {
+
+                expect(err).to.be.an.error(Exceptions.SubscriptionExistError);
+                done();
+            });
+        });
+
+        it('should throw SubscriptionBlockedError when calling subscribe against a blocked queue', (done) => {
+
+            instance.subscriptions.block(queueName);
+
+            instance.subscribe(queueName, handlers, (err) => {
+
+                expect(err).to.be.an.error(Exceptions.SubscriptionBlockedError);
+                done();
+            });
+        });
+    });
+
     describe('acknowledge', () => {
 
         const payload = {

--- a/test/integration-promise.js
+++ b/test/integration-promise.js
@@ -268,7 +268,7 @@ describe('positive integration tests - Promise api', () => {
             return Assertions.assertSendPromise(instance, message, queueName, null, null);
         });
 
-        it('should proxy `callingModule` when supplied', () => {
+        it('should proxy `source` when supplied', () => {
 
             return Assertions.assertSendPromise(instance, message, queueName, null, 'someModule');
         });
@@ -338,7 +338,7 @@ describe('positive integration tests - Promise api', () => {
             return Assertions.assertPublishPromise(instance, message, queueName, 'z', null, null, false);
         });
 
-        it('should proxy `callingModule` when supplied', () => {
+        it('should proxy `source` when supplied', () => {
 
             return Assertions.assertPublishPromise(instance, message, queueName, 'a', null, 'someModule', true);
         });
@@ -714,7 +714,7 @@ describe('positive integration tests - Promise api', () => {
         it('should requeue with well formed header properties', () => {
 
             const publishOptions = {
-                callingModule : 'test'
+                source : 'test'
             };
 
             let transactionId = null;
@@ -734,7 +734,7 @@ describe('positive integration tests - Promise api', () => {
 
                     expect(payload.properties.headers.transactionId).to.equal(transactionId);
                     expect(payload.properties.headers.createAt).to.equal(createdAt);
-                    expect(payload.properties.headers.callingModule).to.equal(publishOptions.callingModule);
+                    expect(payload.properties.headers.source).to.equal(publishOptions.source);
                     expect(payload.properties.headers.requeuedAt).to.exist();
                     expect(payload.properties.headers.retryCount).to.equal(1);
                 });
@@ -800,7 +800,7 @@ describe('positive integration tests - Promise api', () => {
         it('should requeue with well formed header properties', () => {
 
             const publishOptions = {
-                callingModule : 'test'
+                source : 'test'
             };
             const requeuedAt = (new Date()).toISOString();
             const retryCount = 5;
@@ -823,7 +823,7 @@ describe('positive integration tests - Promise api', () => {
 
                     expect(payload.properties.headers.transactionId).to.equal(transactionId);
                     expect(payload.properties.headers.createAt).to.equal(createdAt);
-                    expect(payload.properties.headers.callingModule).to.equal(publishOptions.callingModule);
+                    expect(payload.properties.headers.source).to.equal(publishOptions.source);
                     expect(payload.properties.headers.requeuedAt).to.equal(requeuedAt);
                     expect(payload.properties.headers.retryCount).to.equal(retryCount);
                     expect(payload.properties.headers.errorAt).to.exist();

--- a/test/integration-promise.js
+++ b/test/integration-promise.js
@@ -974,6 +974,45 @@ describe('negative integration tests', () => {
         });
     });
 
+    describe('subscribe', () => {
+
+        const queueName = 'test-queue-1';
+        const consumerTag = 'abcde12345';
+        const handlers = { event1 : () => {} };
+
+        afterEach((done) => {
+
+            instance.subscriptions._subscriptions.clear();
+            instance.subscriptions._blockQueues.clear();
+            done();
+        });
+
+        it('should throw SubscriptionExistError when calling subscribe on an active subscription exist', () => {
+
+            instance.subscriptions.create(queueName, handlers);
+            instance.subscriptions.tag(queueName, consumerTag);
+
+            return instance.subscribe(queueName, handlers)
+                .then(throwError)
+                .catch((err) => {
+
+                    expect(err).to.be.an.error(Exceptions.SubscriptionExistError);
+                });
+        });
+
+        it('should throw SubscriptionBlockedError when calling subscribe against a blocked queue', () => {
+
+            instance.subscriptions.block(queueName);
+
+            return instance.subscribe(queueName, handlers)
+                .then(throwError)
+                .catch((err) => {
+
+                    expect(err).to.be.an.error(Exceptions.SubscriptionBlockedError);
+                });
+        });
+    });
+
     describe('acknowledge', () => {
 
         const payload = {

--- a/test/states.js
+++ b/test/states.js
@@ -38,16 +38,14 @@ describe('state management', () => {
             it('should create one if it does not exist', (done) => {
 
                 const queueName = `${baseQueueName}-1`;
-                const consumerTag = 'abcdefg012345';
                 const handlers = { event1 : () => {} };
                 const options = {};
 
-                const response = instance.create(queueName, consumerTag, handlers, options);
+                const response = instance.create(queueName, handlers, options);
                 const sut = instance._subscriptions.get(queueName);
 
                 expect(response).to.be.true();
                 expect(sut).to.exist();
-                expect(sut.consumerTag).to.equal(consumerTag);
                 expect(sut.handlers).to.exist();
                 expect(sut.handlers.event1).to.be.a.function();
                 expect(sut.options).to.exist();
@@ -57,12 +55,11 @@ describe('state management', () => {
             it('should not create one if it does exist', (done) => {
 
                 const queueName = `${baseQueueName}-2`;
-                const consumerTag = 'abcdefg012345';
                 const handlers = { event1 : () => {} };
                 const options = {};
 
-                instance.create(queueName, consumerTag, handlers, options);
-                const response = instance.create(queueName, consumerTag, handlers, options);
+                instance.create(queueName, handlers, options);
+                const response = instance.create(queueName, handlers, options);
 
                 expect(response).to.be.false();
                 done();
@@ -71,11 +68,63 @@ describe('state management', () => {
             it('should subscribe to `subscription.created` event', (done) => {
 
                 const queueName = `${baseQueueName}-3`;
-                const consumerTag = 'abcdefg012345';
                 const handlers = { event1 : () => {} };
                 const options = {};
 
                 instance.once(SubscriptionManager.CREATED_EVENT, (subcription) => {
+
+                    expect(subcription).to.exist();
+                    expect(subcription.handlers).to.exist();
+                    expect(subcription.handlers.event1).to.be.a.function();
+                    expect(subcription.options).to.exist();
+                    done();
+                });
+
+                instance.create(queueName, handlers, options);
+            });
+        });
+
+        describe('tag', () => {
+
+            const baseQueueName = 'subscription-tagSubscription';
+
+            it('should return true when subscription exist', (done) => {
+
+                const queueName = `${baseQueueName}-1`;
+                const consumerTag = 'abcdefg012345';
+                const handlers = { event1 : () => {} };
+                const options = {};
+
+                instance.create(queueName, handlers, options);
+                const response = instance.tag(queueName, consumerTag);
+                const sut = instance._subscriptions.get(queueName).hasOwnProperty('consumerTag');
+
+                expect(response).to.be.true();
+                expect(sut).to.be.true();
+
+                done();
+            });
+
+            it('should return false when subscription does not exist', (done) => {
+
+                const queueName = `${baseQueueName}-2`;
+                const consumerTag = 'abcdefg012345';
+
+                const response = instance.tag(queueName, consumerTag);
+
+                expect(response).to.be.false();
+
+                done();
+            });
+
+            it('should subscribe to `subscription.tagged` event', (done) => {
+
+                const queueName = `${baseQueueName}-3`;
+                const consumerTag = 'abcdefg012345';
+                const handlers = { event1 : () => {} };
+                const options = {};
+
+                instance.once(SubscriptionManager.TAGGED_EVENT, (subcription) => {
 
                     expect(subcription).to.exist();
                     expect(subcription.consumerTag).to.equal(consumerTag);
@@ -85,7 +134,8 @@ describe('state management', () => {
                     done();
                 });
 
-                instance.create(queueName, consumerTag, handlers, options);
+                instance.create(queueName, handlers, options);
+                instance.tag(queueName, consumerTag);
             });
         });
 
@@ -100,7 +150,8 @@ describe('state management', () => {
                 const handlers = { event1 : () => {} };
                 const options = {};
 
-                instance.create(queueName, consumerTag, handlers, options);
+                instance.create(queueName, handlers, options);
+                instance.tag(queueName, consumerTag);
                 const sut = instance.get(queueName);
 
                 expect(sut).to.exist();
@@ -132,7 +183,8 @@ describe('state management', () => {
                 const handlers = { event1 : () => {} };
                 const options = {};
 
-                instance.create(queueName, consumerTag, handlers, options);
+                instance.create(queueName, handlers, options);
+                instance.tag(queueName, consumerTag);
                 const response = instance.clear(queueName);
                 const sut = instance._subscriptions.get(queueName).hasOwnProperty('consumerTag');
 
@@ -144,12 +196,10 @@ describe('state management', () => {
             it('should return false when subscription exist but does not have a consumerTag', (done) => {
 
                 const queueName = `${baseQueueName}-2`;
-                const consumerTag = 'abcdefg012345';
                 const handlers = { event1 : () => {} };
                 const options = {};
 
-                instance.create(queueName, consumerTag, handlers, options);
-                delete instance._subscriptions.get(queueName).consumerTag;
+                instance.create(queueName, handlers, options);
                 const response = instance.clear(queueName);
 
                 expect(response).to.be.false();
@@ -179,7 +229,8 @@ describe('state management', () => {
                     done();
                 });
 
-                instance.create(queueName, consumerTag, handlers, options);
+                instance.create(queueName, handlers, options);
+                instance.tag(queueName, consumerTag);
                 instance.clear(queueName);
             });
         });
@@ -205,7 +256,8 @@ describe('state management', () => {
                 const handlers = { event1 : () => {} };
                 const options = {};
 
-                instance.create(queueName, consumerTag, handlers, options);
+                instance.create(queueName, handlers, options);
+                instance.tag(queueName, consumerTag);
                 const response = instance.contains(queueName);
 
                 expect(response).to.be.true();
@@ -215,12 +267,10 @@ describe('state management', () => {
             it('should return true when subscription does exist with removed consumerTag when using flag override', (done) => {
 
                 const queueName = `${baseQueueName}-3`;
-                const consumerTag = 'abcdefg012345';
                 const handlers = { event1 : () => {} };
                 const options = {};
 
-                instance.create(queueName, consumerTag, handlers, options);
-                delete instance._subscriptions.get(queueName).consumerTag;
+                instance.create(queueName, handlers, options);
                 const response = instance.contains(queueName, false);
 
                 expect(response).to.be.true();
@@ -249,7 +299,8 @@ describe('state management', () => {
                 const handlers = { event1 : () => {} };
                 const options = {};
 
-                instance.create(queueName, consumerTag, handlers, options);
+                instance.create(queueName, handlers, options);
+                instance.tag(queueName, consumerTag);
                 const response = instance.remove(queueName);
 
                 expect(response).to.be.true();
@@ -259,12 +310,10 @@ describe('state management', () => {
             it('should return true when subscription exist with no consumerTag', (done) => {
 
                 const queueName = `${baseQueueName}-2`;
-                const consumerTag = 'abcdefg012345';
                 const handlers = { event1 : () => {} };
                 const options = {};
 
-                instance.create(queueName, consumerTag, handlers, options);
-                delete instance._subscriptions.get(queueName).consumerTag;
+                instance.create(queueName, handlers, options);
                 const response = instance.remove(queueName);
 
                 expect(response).to.be.true();
@@ -274,7 +323,6 @@ describe('state management', () => {
             it('should subscribe to `subscription.removed` event', (done) => {
 
                 const queueName = `${baseQueueName}-4`;
-                const consumerTag = 'abcdefg012345';
                 const handlers = { event1 : () => {} };
                 const options = {};
 
@@ -284,7 +332,7 @@ describe('state management', () => {
                     done();
                 });
 
-                instance.create(queueName, consumerTag, handlers, options);
+                instance.create(queueName, handlers, options);
                 instance.remove(queueName);
             });
         });
@@ -297,11 +345,10 @@ describe('state management', () => {
 
                 for (let i = 1; i <= 3; ++i) {
                     const queueName = `${baseQueueName}-${i}`;
-                    const consumerTag = 'abcdefg012345';
                     const handlers = { event1 : () => {} };
                     const options = {};
 
-                    instance.create(queueName, consumerTag, handlers, options);
+                    instance.create(queueName, handlers, options);
                 }
 
                 const results = instance.list();
@@ -311,7 +358,7 @@ describe('state management', () => {
             });
         });
 
-        describe('block/unblock', () => {
+        describe('block/unblock/isBlocked', () => {
 
             it('should be true when blocking queue is unique', (done) => {
 
@@ -380,6 +427,27 @@ describe('state management', () => {
 
                 instance.block(queueName);
                 instance.unblock(queueName);
+            });
+
+            it('should be true when block queue exist', (done) => {
+
+                const queueName = 'queue7';
+
+                instance.block(queueName);
+                const result = instance.isBlocked(queueName);
+
+                expect(result).to.be.true();
+                done();
+            });
+
+            it('should be false when block queue does not exist', (done) => {
+
+                const queueName = 'queue8';
+
+                const result = instance.isBlocked(queueName);
+
+                expect(result).to.be.false();
+                done();
             });
         });
     });


### PR DESCRIPTION
## Description
This is the final TODO body of work.

- Fixed `subscribe()` to abide by the desired state of blocked queues within `SubcriptionManager`.  The fix was made to check the queue state before consume is invoked during the synchronous call.
- Changed the name of `callingModule` to `source` within the `payload.properties.headers` of the RMQ message.  I felt the name needed to be changed to be more generic and explicit. 
- Updated `API.md` documentation for everyting

## Related Issue
- #32 

## Motivation and Context
To fix all deferred issues before v1.0.0

## Types of changes
- [ ] Documentation only (no changes to either `lib/` or `test/` files)
- [x] Bug fix (non-breaking change which fixes an issue. you didn't modify existing tests)
- [x] New feature (non-breaking change which adds functionality. you added at least one new test)
- [x] Breaking change (fix or feature that would cause existing functionality to change. you had to modify existing tests.)

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/xogroup/bunnybus/blob/master/.github/CONTRIBUTING.md) document.
- [x] My code follows the [Hapi.js style guide](https://github.com/hapijs/contrib/blob/master/Style.md).
- [x] I have updated the documentation as needed.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.