### PR TITLE
added state handling for when the channel is closed.  

### DIFF
--- a/API.md
+++ b/API.md
@@ -86,6 +86,8 @@ Setter and Getter for singleton configuration. Accepts the following optional pr
  * `globalExchange` - value of the exchange to transact through for message publishing.  This is the default used when one is not provided as an within the `options` for any `BunnyBus` methods that supports one transactionally.  Defaults to `default-exchange`. *[string]* **Optional**
  * `prefetch` - value of the maximum number of unacknowledged messages allowable in a channel.  Defaults to `5`. *[number]* **Optional**
 
+Note that updates in the options directed at changing connection string will not take affect immediately.  `_closeConnection()`](#_closeConnectioncallback) needs to be called manually to invoke a new connection with new settings.
+
   ```Javascript
   const BunnyBus = require('bunnybus');
   const bunnybus = new BunnyBus();

--- a/lib/index.js
+++ b/lib/index.js
@@ -25,9 +25,7 @@ class BunnyBus extends EventEmitter{
             $ = this;
 
             $._state = {
-                recovery      : false,
-                exchanges     : [], // { name }
-                queues        : []  // { name }
+                recovery      : false
             };
 
             $.logger = new EventLogger($);
@@ -126,7 +124,7 @@ class BunnyBus extends EventEmitter{
     }
 
     set config(value) {
-//TODO need to destroy state and reevaluate when this happens
+
         $._config = Object.assign({}, $._config || BunnyBus.DEFAULT_SERVER_CONFIGURATION, value);
     }
 
@@ -596,7 +594,6 @@ class BunnyBus extends EventEmitter{
         }
     }
 
-//options to store calling module, queue name, error queue name
     _reject(payload, errorQueue, options, callback) {
 
         callback = Helpers.reduceCallback(options, callback);
@@ -717,7 +714,12 @@ class BunnyBus extends EventEmitter{
             (cb) => {
 
                 if ($.hasConnection) {
-                    $.connection.close(cb);
+
+                    $.connection.close((err) => {
+
+                        $.connection = null;
+                        cb(err);
+                    });
                 }
                 else {
                     cb();
@@ -725,9 +727,9 @@ class BunnyBus extends EventEmitter{
             }
         ], (err) => {
 
-            if (!err) {
-                $.connection = null;
-            }
+            // if (!err) {
+            //     $.connection = null;
+            // }
 
             callback(err);
         });
@@ -748,6 +750,7 @@ class BunnyBus extends EventEmitter{
                     cb(new Exceptions.NoConnectionError());
                 }
                 else if (!$.hasChannel) {
+                    $.subscriptions.clearAll();
                     $.connection.createConfirmChannel(cb);
                 }
                 else {

--- a/lib/states/subscriptionManager.js
+++ b/lib/states/subscriptionManager.js
@@ -99,6 +99,13 @@ class SubscriptionManager extends EventEmitter {
         return false;
     }
 
+    clearAll() {
+
+        for (const [queue] of this._subscriptions) {
+            this.clear(queue);
+        }
+    }
+
     remove(queue) {
 
         if (this.contains(queue, false)) {

--- a/test/states.js
+++ b/test/states.js
@@ -235,6 +235,41 @@ describe('state management', () => {
             });
         });
 
+        describe('clearAll', () => {
+
+            const baseQueueName = 'subscription-clearAllSubscription';
+
+            it('should return true when subscription is cleared', (done) => {
+
+                const handlers = { event1 : () => {} };
+                const options = {};
+                const iterationLimit = 5;
+                let iterationCount = 0;
+
+                for (let i = 1; i <= iterationLimit; ++i) {
+                    const queueName = `${baseQueueName}-${i}`;
+                    const consumerTag = `abcdefg012345-${1}`;
+                    instance.create(queueName, handlers, options);
+                    instance.tag(queueName, consumerTag);
+                }
+
+                const eventHandler = (subscription) => {
+
+                    ++iterationCount;
+
+                    expect(subscription).to.exist();
+
+                    if (iterationCount === iterationLimit) {
+                        instance.removeListener(SubscriptionManager.CLEARED_EVENT, eventHandler);
+                        done();
+                    }
+                };
+
+                instance.on(SubscriptionManager.CLEARED_EVENT, eventHandler);
+                instance.clearAll();
+            });
+        });
+
         describe('contains', () => {
 
             const baseQueueName = 'subscription-contains';


### PR DESCRIPTION
## Description
- Updated documentation on limitation of `config` setter in reflection with when the connection is affected.
- Cleared out `SubscriptionManager` when `channel` is closed.

## Motivation and Context
Cleaning up low level edge cases.

## Types of changes
- [ ] Documentation only (no changes to either `lib/` or `test/` files)
- [x] Bug fix (non-breaking change which fixes an issue. you didn't modify existing tests)
- [ ] New feature (non-breaking change which adds functionality. you added at least one new test)
- [ ] Breaking change (fix or feature that would cause existing functionality to change. you had to modify existing tests.)

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/xogroup/bunnybus/blob/master/.github/CONTRIBUTING.md) document.
- [x] My code follows the [Hapi.js style guide](https://github.com/hapijs/contrib/blob/master/Style.md).
- [x] I have updated the documentation as needed.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.