### PR TITLE
constructor with undefined options failed to have any defaults

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -159,7 +159,7 @@ class BunnyBus extends EventEmitter{
 
     get connectionString() {
 
-        return Helpers.createConnectionString($._config);
+        return Helpers.createConnectionString($.config);
     }
 
     get connection() {


### PR DESCRIPTION
## Description
When constructor was not presented with any defaults like this:

```
new BunnyBus();

```

The instance failed to start since no configurations was used.

## Motivation and Context
Broke the API contract

## Types of changes
- [ ] Documentation only (no changes to either `lib/` or `test/` files)
- [x] Bug fix (non-breaking change which fixes an issue. you didn't modify existing tests)
- [ ] New feature (non-breaking change which adds functionality. you added at least one new test)
- [ ] Breaking change (fix or feature that would cause existing functionality to change. you had to modify existing tests.)

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/xogroup/bunnybus/blob/master/.github/CONTRIBUTING.md) document.
- [x] My code follows the [Hapi.js style guide](https://github.com/hapijs/contrib/blob/master/Style.md).
- [ ] I have updated the documentation as needed.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.