### PR TITLE
changed errorAt and createAt keys

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -578,7 +578,7 @@ class BunnyBus extends EventEmitter{
                     transactionId : payload.properties.headers.transactionId,
                     isBuffer      : payload.properties.headers.isBuffer,
                     source : payload.properties.headers.source,
-                    createAt      : payload.properties.headers.createdAt,
+                    createdAt      : payload.properties.headers.createdAt,
                     requeuedAt    : (new Date()).toISOString(),
                     retryCount    : payload.properties.headers.retryCount || 0,
                     routeKey
@@ -616,9 +616,9 @@ class BunnyBus extends EventEmitter{
                     transactionId : payload.properties.headers.transactionId,
                     isBuffer      : payload.properties.headers.isBuffer,
                     source : payload.properties.headers.source,
-                    createAt      : payload.properties.headers.createdAt,
+                    createdAt      : payload.properties.headers.createdAt,
                     requeuedAt    : payload.properties.headers.requeuedAt,
-                    errorAt       : (new Date()).toISOString(),
+                    erroredAt       : (new Date()).toISOString(),
                     retryCount    : payload.properties.headers.retryCount || 0
                 }
             };

--- a/test/integration-callback.js
+++ b/test/integration-callback.js
@@ -824,7 +824,7 @@ describe('positive integration tests - Callback api', () => {
 
                 expect(err).to.be.null();
                 expect(payload.properties.headers.transactionId).to.equal(transactionId);
-                expect(payload.properties.headers.createAt).to.equal(createdAt);
+                expect(payload.properties.headers.createdAt).to.equal(createdAt);
                 expect(payload.properties.headers.source).to.equal(publishOptions.source);
                 expect(payload.properties.headers.requeuedAt).to.exist();
                 expect(payload.properties.headers.retryCount).to.equal(1);
@@ -923,11 +923,11 @@ describe('positive integration tests - Callback api', () => {
 
                 expect(err).to.be.null();
                 expect(payload.properties.headers.transactionId).to.equal(transactionId);
-                expect(payload.properties.headers.createAt).to.equal(createdAt);
+                expect(payload.properties.headers.createdAt).to.equal(createdAt);
                 expect(payload.properties.headers.source).to.equal(publishOptions.source);
                 expect(payload.properties.headers.requeuedAt).to.equal(requeuedAt);
                 expect(payload.properties.headers.retryCount).to.equal(retryCount);
-                expect(payload.properties.headers.errorAt).to.exist();
+                expect(payload.properties.headers.erroredAt).to.exist();
                 done();
             });
         });

--- a/test/integration-promise.js
+++ b/test/integration-promise.js
@@ -733,7 +733,7 @@ describe('positive integration tests - Promise api', () => {
                 .then((payload) => {
 
                     expect(payload.properties.headers.transactionId).to.equal(transactionId);
-                    expect(payload.properties.headers.createAt).to.equal(createdAt);
+                    expect(payload.properties.headers.createdAt).to.equal(createdAt);
                     expect(payload.properties.headers.source).to.equal(publishOptions.source);
                     expect(payload.properties.headers.requeuedAt).to.exist();
                     expect(payload.properties.headers.retryCount).to.equal(1);
@@ -822,11 +822,11 @@ describe('positive integration tests - Promise api', () => {
                 .then((payload) => {
 
                     expect(payload.properties.headers.transactionId).to.equal(transactionId);
-                    expect(payload.properties.headers.createAt).to.equal(createdAt);
+                    expect(payload.properties.headers.createdAt).to.equal(createdAt);
                     expect(payload.properties.headers.source).to.equal(publishOptions.source);
                     expect(payload.properties.headers.requeuedAt).to.equal(requeuedAt);
                     expect(payload.properties.headers.retryCount).to.equal(retryCount);
-                    expect(payload.properties.headers.errorAt).to.exist();
+                    expect(payload.properties.headers.erroredAt).to.exist();
                 });
         });
     });


### PR DESCRIPTION
## Description
- updated `errorAt` to `erroredAt`
- updated `createAt` to `createdAt`

## Related Issue
- #43 

## Motivation and Context
Wanted all time related keys to be in past tense.

## Types of changes
- [ ] Documentation only (no changes to either `lib/` or `test/` files)
- [x] Bug fix (non-breaking change which fixes an issue. you didn't modify existing tests)
- [ ] New feature (non-breaking change which adds functionality. you added at least one new test)
- [x] Breaking change (fix or feature that would cause existing functionality to change. you had to modify existing tests.)

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/xogroup/bunnybus/blob/master/.github/CONTRIBUTING.md) document.
- [ ] My code follows the [Hapi.js style guide](https://github.com/hapijs/contrib/blob/master/Style.md).
- [ ] I have updated the documentation as needed.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.