### PR TITLE
added meta support to subscribe

### DIFF
--- a/API.md
+++ b/API.md
@@ -129,8 +129,9 @@ Setter and Getter for singleton configuration. Accepts the following optional pr
  * `port` - value of the port for client connections.  Used in the conneciton string.  Defaults to `5672`. *[number]* **Optional**
  * `vhost` - value of the virtual host the user connects to.  Used in the connection string.  Defaults to `%2f`. *[string]* **Optional**
  * `heartbeat` -  value negotiated between client and server on when the TCP tunnel is considered dead.  Unit is a measurement of milliseconds.  Used in the connection string.  Defaults to `2000`. *[number]* **Optional**
- * `globalExchange` - value of the exchange to transact through for message publishing.  This is the default used when one is not provided as an within the `options` for any `BunnyBus` methods that supports one transactionally.  Defaults to `default-exchange`. *[string]* **Optional**
+ * `globalExchange` - value of the exchange to transact through for message publishing.  This is the default used when one is not provided within the `options` for any `BunnyBus` methods that supports one transactionally.  Defaults to `default-exchange`. *[string]* **Optional**
  * `prefetch` - value of the maximum number of unacknowledged messages allowable in a channel.  Defaults to `5`. *[number]* **Optional**
+ * `maxRetryCount` - maximum amount of attempts a message can be requeued.  This is the default used when one is not provided within the `options` for any `BunnyBus` methods that supports one transactionally. Defaults to `10`. *[number]* **Optional**
 
 Note that updates in the options directed at changing connection string will not take affect immediately.  [`_closeConnection()`](#_closeConnectioncallback) needs to be called manually to invoke a new connection with new settings.
 
@@ -441,6 +442,9 @@ Subscribe to messages from the queue.
   - `handlers` - a `key` / `handler` hash where the key reflects the name of the `message.event` or `routeKey`.  And the handler reflects a `Function` as `(message, [ack, [reject, [requeue]]]) => {}`. *[Object]* **Required**
   - `options` - optional settings. *[Object]* **Optional**
     - `queue` - settings for the queue. [Settings](http://www.squaremobius.net/amqp.node/channel_api.html#channel_assertQueue) are proxied through to amqplib `assertQueue`. *[Object]* **Optional**
+    - `globalExchange` - value of the exchange to transact through for message publishing.  Defaults to one provided in the [config](#config). *[string]* **Optional**
+    - `maxRetryCount` - maximum amount of attempts a message can be requeued.  Defaults to one provided in the [config](#config). *[number]* **Optional**
+    - `meta` - allows for meta data regarding the payload to be returned.  Turning this on will adjust the handler to be a `Function` as `(message, meta, [ack, [reject, [requeue]]]) => {}`. *[boolean]* **Optional**
   - `callback` - node style callback `(err, result) => {}`. *[Function]* **Optional**
 
 ##### handlers
@@ -453,6 +457,7 @@ A `key` is the routeKey in RabbitMQ terminology.  `BunnyBus` specifically levera
 
 A `handler` is a function which contains the following arity.  Order matters.
   - `message` is what was received from the bus.  The message does represent the RabbitMQ `'payload.content` buffer.  The original source of this object is from `payload.content`.
+  - `meta` is only available when `options.meta` is set to `true`.  This object will contain all payload related meta information like `payload.properties.headers`.
   - `ack([option, [callback]])` is a function for acknowledging the message off the bus.
     - `option` - a placeholder for future optional parameters for `ack`.  High chance of deprecation.
     - `callback` - node style callback `(err, result) => {}`. *[Function]* **Optional**

--- a/lib/index.js
+++ b/lib/index.js
@@ -442,6 +442,7 @@ class BunnyBus extends EventEmitter{
         const queueOptions = options && options.queue ? options.queue : null;
         const globalExchange = (options && options.globalExchange) || $.config.globalExchange;
         const maxRetryCount = (options && options.maxRetryCount) || $.config.maxRetryCount;
+        const meta = (options && options.meta);
 
         Async.auto({
             initialize      : $._autoConnectChannel,
@@ -478,15 +479,30 @@ class BunnyBus extends EventEmitter{
                         const errorQueue = `${queue}_error`;
                         //should put this in the publish func()
                         // var routeKey = isValidRoute(payload.fields.routingKey) || isValidRoute(message.event);
-
                         if (handlers.hasOwnProperty(routeKey)) {
                             if (currentRetryCount < maxRetryCount) {
-                                handlers[routeKey](
-                                    message,
-                                    $._ack.bind(null, payload),
-                                    $._reject.bind(null, payload, errorQueue),
-                                    $._requeue.bind(null, payload, queue, { routeKey })
-                                );
+                                if (meta) {
+                                    //TODO: put this into a helper function as a refactor
+                                    const metadata = {
+                                        headers : Object.assign({}, payload.properties.headers)
+                                    };
+
+                                    handlers[routeKey](
+                                        message,
+                                        metadata,
+                                        $._ack.bind(null, payload),
+                                        $._reject.bind(null, payload, errorQueue),
+                                        $._requeue.bind(null, payload, queue, { routeKey })
+                                    );
+                                }
+                                else {
+                                    handlers[routeKey](
+                                        message,
+                                        $._ack.bind(null, payload),
+                                        $._reject.bind(null, payload, errorQueue),
+                                        $._requeue.bind(null, payload, queue, { routeKey })
+                                    );
+                                }
                             }
                             else {
                                 $._reject(payload, errorQueue);

--- a/test/integration-callback.js
+++ b/test/integration-callback.js
@@ -403,6 +403,7 @@ describe('positive integration tests - Callback api', () => {
         const queueName = 'test-subscribe-queue-1';
         const errorQueueName = `${queueName}_error`;
         const publishOptions = { routeKey : 'a.b' };
+        const subscribeOptions = { meta : true };
         const messageObject = { event : 'a.b', name : 'bunnybus' };
         const messageString = 'bunnybus';
         const messageBuffer = new Buffer(messageString);
@@ -453,6 +454,29 @@ describe('positive integration tests - Callback api', () => {
             });
         });
 
+        it('should consume message (Object) and meta from queue and acknowledge off', (done) => {
+
+            const handlers = {};
+            handlers[messageObject.event] = (consumedMessage, meta, ack) => {
+
+                expect(consumedMessage).to.equal(messageObject);
+                expect(meta).to.not.be.a.function();
+                expect(meta.headers).to.exist();
+                ack(null, done);
+            };
+
+            Async.waterfall([
+                instance.subscribe.bind(instance, queueName, handlers, subscribeOptions),
+                instance.publish.bind(instance, messageObject)
+            ],
+            (err) => {
+
+                if (err) {
+                    done(err);
+                }
+            });
+        });
+
         it('should consume message (String) from queue and acknowledge off', (done) => {
 
             const handlers = {};
@@ -474,6 +498,29 @@ describe('positive integration tests - Callback api', () => {
             });
         });
 
+        it('should consume message (String) and meta from queue and acknowledge off', (done) => {
+
+            const handlers = {};
+            handlers[publishOptions.routeKey] = (consumedMessage, meta, ack) => {
+
+                expect(consumedMessage).to.equal(messageString);
+                expect(meta).to.not.be.a.function();
+                expect(meta.headers).to.exist();
+                ack(null, done);
+            };
+
+            Async.waterfall([
+                instance.subscribe.bind(instance, queueName, handlers, subscribeOptions),
+                instance.publish.bind(instance, messageString, publishOptions)
+            ],
+            (err) => {
+
+                if (err) {
+                    done(err);
+                }
+            });
+        });
+
         it('should consume message (Buffer) from queue and acknowledge off', (done) => {
 
             const handlers = {};
@@ -485,6 +532,29 @@ describe('positive integration tests - Callback api', () => {
 
             Async.waterfall([
                 instance.subscribe.bind(instance, queueName, handlers),
+                instance.publish.bind(instance, messageBuffer, publishOptions)
+            ],
+            (err) => {
+
+                if (err) {
+                    done(err);
+                }
+            });
+        });
+
+        it('should consume message (Buffer) and meta from queue and acknowledge off', (done) => {
+
+            const handlers = {};
+            handlers[publishOptions.routeKey] = (consumedMessage, meta, ack) => {
+
+                expect(consumedMessage).to.equal(messageBuffer);
+                expect(meta).to.not.be.a.function();
+                expect(meta.headers).to.exist();
+                ack(null, done);
+            };
+
+            Async.waterfall([
+                instance.subscribe.bind(instance, queueName, handlers, subscribeOptions),
                 instance.publish.bind(instance, messageBuffer, publishOptions)
             ],
             (err) => {

--- a/test/integration-promise.js
+++ b/test/integration-promise.js
@@ -361,6 +361,7 @@ describe('positive integration tests - Promise api', () => {
         const queueName = 'test-subscribe-queue-1';
         const errorQueueName = `${queueName}_error`;
         const publishOptions = { routeKey : 'a.b' };
+        const subscribeOptions = { meta : true };
         const messageObject = { event : 'a.b', name : 'bunnybus' };
         const messageString = 'bunnybus';
         const messageBuffer = new Buffer(messageString);
@@ -406,6 +407,28 @@ describe('positive integration tests - Promise api', () => {
             });
         });
 
+        it('should consume message (Object) and meta from queue and acknowledge off', () => {
+
+            return new Promise((resolve, reject) => {
+
+                const handlers = {};
+
+                handlers[messageObject.event] = (consumedMessage, meta, ack) => {
+
+                    expect(consumedMessage).to.equal(messageObject);
+                    expect(meta).to.not.be.a.function();
+                    expect(meta.headers).to.exist();
+
+                    return ack()
+                        .then(resolve);
+                };
+
+                return instance.subscribe(queueName, handlers, subscribeOptions)
+                    .then(instance.publish.bind(instance, messageObject))
+                    .catch(reject);
+            });
+        });
+
         it('should consume message (String) from queue and acknowledge off', () => {
 
             return new Promise((resolve, reject) => {
@@ -426,6 +449,28 @@ describe('positive integration tests - Promise api', () => {
             });
         });
 
+        it('should consume message (String) and meta from queue and acknowledge off', () => {
+
+            return new Promise((resolve, reject) => {
+
+                const handlers = {};
+
+                handlers[publishOptions.routeKey] = (consumedMessage, meta, ack) => {
+
+                    expect(consumedMessage).to.equal(messageString);
+                    expect(meta).to.not.be.a.function();
+                    expect(meta.headers).to.exist();
+
+                    return ack()
+                        .then(resolve);
+                };
+
+                return instance.subscribe(queueName, handlers, subscribeOptions)
+                    .then(instance.publish.bind(instance, messageString, publishOptions))
+                    .catch(reject);
+            });
+        });
+
         it('should consume message (Buffer) from queue and acknowledge off', () => {
 
             return new Promise((resolve, reject) => {
@@ -441,6 +486,28 @@ describe('positive integration tests - Promise api', () => {
                 };
 
                 return instance.subscribe(queueName, handlers)
+                    .then(instance.publish.bind(instance, messageBuffer, publishOptions))
+                    .catch(reject);
+            });
+        });
+
+        it('should consume message (Buffer) and meta from queue and acknowledge off', () => {
+
+            return new Promise((resolve, reject) => {
+
+                const handlers = {};
+
+                handlers[publishOptions.routeKey] = (consumedMessage, meta, ack) => {
+
+                    expect(consumedMessage).to.equal(messageBuffer);
+                    expect(meta).to.not.be.a.function();
+                    expect(meta.headers).to.exist();
+
+                    return ack()
+                        .then(resolve);
+                };
+
+                return instance.subscribe(queueName, handlers, subscribeOptions)
                     .then(instance.publish.bind(instance, messageBuffer, publishOptions))
                     .catch(reject);
             });


### PR DESCRIPTION
## Description
- Added support for bubbling up meta data to the subscriber handlers when `options.meta` is set.
- Added missing documentation for some options that exist in `subscribe()`

## Related Issue
- #42 

## Motivation and Context
Some users need the payload header information to be bubbled out in order to act on the payload in a complete fashion. 

## Types of changes
- [ ] Documentation only (no changes to either `lib/` or `test/` files)
- [ ] Bug fix (non-breaking change which fixes an issue. you didn't modify existing tests)
- [x] New feature (non-breaking change which adds functionality. you added at least one new test)
- [ ] Breaking change (fix or feature that would cause existing functionality to change. you had to modify existing tests.)

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/xogroup/bunnybus/blob/master/.github/CONTRIBUTING.md) document.
- [x] My code follows the [Hapi.js style guide](https://github.com/hapijs/contrib/blob/master/Style.md).
- [x] I have updated the documentation as needed.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.