### PR TITLE
fixed race condition for parallel use case

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -25,7 +25,9 @@ class BunnyBus extends EventEmitter{
             $ = this;
 
             $._state = {
-                recovery      : false
+                recovery            : false,
+                connectionSemaphore : 0,
+                channelSemaphore    : 0
             };
 
             $.logger = new EventLogger($);
@@ -713,6 +715,28 @@ class BunnyBus extends EventEmitter{
         Async.waterfall([
             (cb) => {
 
+                if ($._state.connectionSemaphore++ > 0) {
+                    Async.retry({
+                        times : 200,
+                        interval : 100
+                    },
+                    (retryCB) => {
+
+                        if ($._state.connectionSemaphore > 0) {
+                            retryCB(1);
+                        }
+                        else {
+                            retryCB();
+                        }
+                    },
+                    cb);
+                }
+                else {
+                    cb();
+                }
+            },
+            (cb) => {
+
                 if (!$.hasConnection) {
                     Amqp.connect($.connectionString, cb);
                 }
@@ -726,6 +750,7 @@ class BunnyBus extends EventEmitter{
                     $.connection = connection;
                 }
 
+                $._state.connectionSemaphore = 0;
                 cb();
             }
         ], callback);
@@ -775,7 +800,30 @@ class BunnyBus extends EventEmitter{
         Async.waterfall([
             (cb) => {
 
+                if ($._state.channelSemaphore++ > 0) {
+                    Async.retry({
+                        times : 200,
+                        interval : 100
+                    },
+                    (retryCB) => {
+
+                        if ($._state.channelSemaphore > 0) {
+                            retryCB(1);
+                        }
+                        else {
+                            retryCB();
+                        }
+                    },
+                    cb);
+                }
+                else {
+                    cb();
+                }
+            },
+            (cb) => {
+
                 if (!$.hasConnection) {
+                    $._state.channelSemaphore = 0;
                     cb(new Exceptions.NoConnectionError());
                 }
                 else if (!$.hasChannel) {
@@ -792,6 +840,7 @@ class BunnyBus extends EventEmitter{
                     $.channel = channel;
                 }
 
+                $._state.channelSemaphore = 0;
                 cb();
             },
             (cb) => {

--- a/test/integration-callback.js
+++ b/test/integration-callback.js
@@ -1035,7 +1035,7 @@ describe('positive integration tests - Callback api', () => {
             });
         });
 
-        it('should requeue with well formed header properties', (done) => {
+        it('should reject with well formed header properties', (done) => {
 
             const publishOptions = {
                 source : 'test'


### PR DESCRIPTION
## Description

- There was a bug when any of the methods that leveraged `_autoConnectChannel` was invoked in a parallel fashion raising a race condition on side to side instantiations of TCP connections.  A semaphore is put in place to prevent this.

## Related Issue
- #53 

## Motivation and Context
Bug

## Types of changes
- [ ] Documentation only (no changes to either `lib/` or `test/` files)
- [x] Bug fix (non-breaking change which fixes an issue. you didn't modify existing tests)
- [ ] New feature (non-breaking change which adds functionality. you added at least one new test)
- [ ] Breaking change (fix or feature that would cause existing functionality to change. you had to modify existing tests.)

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/xogroup/bunnybus/blob/master/.github/CONTRIBUTING.md) document.
- [x] My code follows the [Hapi.js style guide](https://github.com/hapijs/contrib/blob/master/Style.md).
- [ ] I have updated the documentation as needed.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.