### PR TITLE
Fixed bug with subscribe not identifying proper route key

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -472,7 +472,7 @@ class BunnyBus extends EventEmitter{
                         $.logger.trace(payload);
 
                         const message = payload.properties.headers.isBuffer ? payload.content : JSON.parse(payload.content.toString());
-                        const routeKey = Helpers.reduceRouteKey(payload);
+                        const routeKey = Helpers.reduceRouteKey(payload, null, message);
                         const currentRetryCount = payload.properties.headers.retryCount || -1;
                         const errorQueue = `${queue}_error`;
 

--- a/test/integration-edge-case.js
+++ b/test/integration-edge-case.js
@@ -45,5 +45,33 @@ describe('positive integration tests - Callback api', () => {
                 done();
             });
         });
+
+        it.only('should pass when get pushes a message to a subscribed queue', (done) => {
+
+            const message = { event : 'ea', name : 'bunnybus' };
+            const queueName = 'edge-case-get-to-subscribe';
+            let counter = 0;
+            const handlers = {
+                ea : (subscribedMessaged, ack) => {
+
+                    expect(subscribedMessaged).to.be.equal(message);
+                    resolve();
+                }
+            };
+            const resolve = () => {
+
+                if (++counter === 2) {
+                    done();
+                }
+            };
+
+            Async.waterfall([
+                (cb) => instance._autoConnectChannel(cb),
+                (cb) => instance.createQueue(queueName, cb),
+                (result, cb) => instance.send(message, queueName, cb),
+                (cb) => instance.subscribe(queueName, handlers, cb),
+                (cb) => instance.deleteQueue(queueName, cb)
+            ], resolve);
+        });
     });
 });


### PR DESCRIPTION
## Description
Fixed bug with `subscribe()` not identifying proper `routeKey` when available through the message content of the `payload.content`

## Related Issue
* #58

## Types of changes
- [ ] Documentation only (no changes to either `lib/` or `test/` files)
- [x] Bug fix (non-breaking change which fixes an issue. you didn't modify existing tests)
- [ ] New feature (non-breaking change which adds functionality. you added at least one new test)
- [ ] Breaking change (fix or feature that would cause existing functionality to change. you had to modify existing tests.)

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/xogroup/bunnybus/blob/master/.github/CONTRIBUTING.md) document.
- [x] My code follows the [Hapi.js style guide](https://github.com/hapijs/contrib/blob/master/Style.md).
- [ ] I have updated the documentation as needed.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.