### PR TITLE
send command to supply route key

### DIFF
--- a/API.md
+++ b/API.md
@@ -41,6 +41,7 @@
     - [`unsubscribe(queue, [callback])`](#unsubscribequeue-callback)
       - [parameter(s)](#parameters-8)
     - [`send(message, queue, [options, [callback]])`](#sendmessage-queue-options-callback)
+      - [note(s)](#notes)
       - [parameter(s)](#parameters-9)
     - [`get(queue, [options, [callback]])`](#getqueue-options-callback)
       - [parameter(s)](#parameters-10)
@@ -538,11 +539,17 @@ bunnyBus.unsubscribe('queue1')
 
 Send a message directly to a queue.
 
+##### note(s)
+
+When `message.event` or `options.routeKey` values are not provided for `routeKey` addressing.  The message will be lost when [`subcribe()`](#subscribequeue-handlers-options-callback) handles the queue because messages without a `routeKey` are discarded.
+
 ##### parameter(s)
 
   - `message` - the content being sent directly to specfied queue. *[string|Object|Buffer]* **Required**
+   - `event` - override value for the route key. The value must be supplied here or in `options.routeKey`.  The value can be `.` separated for namespacing. *[string]* **Optional.**
   - `queue` - the name of the queue. *[string]* **Required**
   - `options` - optional settings. *[Object]* **Optional**
+    - `routeKey` - value for the route key to route the message with.  The value must be supplied here or in `message.event`.  The value can be `.` separated for namespacing. *[string]* **Optional**
     - `transactionId` - value attached to the header of the message for tracing.  When one is not supplied, a random 40 character token is generated. *[string]*  **Optional**
     - `source` - value attached to the header of the message to help with tracking the origination point of your application.  For applications that leverage this plugin in multiple modules, each module can supply its own module name so a message can be tracked to the creator. *[string]*  **Optional**
   - `callback` - node style callback `(err, result) => {}`. *[Function]* **Optional**

--- a/lib/index.js
+++ b/lib/index.js
@@ -309,6 +309,7 @@ class BunnyBus extends EventEmitter{
             return Helpers.toPromise($.promise, $.send, message, queue, options);
         }
 
+        const routeKey = Helpers.reduceRouteKey(null, options, message);
         const source = (options && options.source);
 
         Async.auto({
@@ -331,6 +332,7 @@ class BunnyBus extends EventEmitter{
                         transactionId : results.create_transaction_id,
                         isBuffer      : results.convert_message.buffer.isBuffer,
                         source,
+                        routeKey,
                         createdAt     : (new Date()).toISOString(),
                         bunnyBus      : Helpers.getPackageData().version
                     }
@@ -390,7 +392,6 @@ class BunnyBus extends EventEmitter{
                     Helpers.createTransactionId(cb);
                 }
             },
-            //cache the exchange
             create_exchange      : ['initialize', (results, cb) => $.createExchange(globalExchange, 'topic', null, cb)],
             publish              : ['create_exchange', (results, cb) => {
 

--- a/test/assertions/assertSend.js
+++ b/test/assertions/assertSend.js
@@ -4,11 +4,12 @@ const Async = require('async');
 const Code = require('code');
 const expect = Code.expect;
 
-const assertSend = (instance, message, queueName, transactionId, source, callback) => {
+const assertSend = (instance, message, queueName, transactionId, source, routeKey, callback) => {
 
     const options = {
         transactionId,
-        source
+        source,
+        routeKey
     };
 
     Async.waterfall([
@@ -35,6 +36,14 @@ const assertSend = (instance, message, queueName, transactionId, source, callbac
 
         if (source) {
             expect(payload.properties.headers.source).to.be.equal(source);
+        }
+
+        if (routeKey) {
+            expect(payload.properties.headers.routeKey).to.be.equal(routeKey);
+        }
+
+        if (message.event) {
+            expect(payload.properties.headers.routeKey).to.be.equal(message.event);
         }
 
         instance.channel.ack(payload);

--- a/test/assertions/assertSendPromise.js
+++ b/test/assertions/assertSendPromise.js
@@ -3,11 +3,12 @@
 const Code = require('code');
 const expect = Code.expect;
 
-const assertSendPromise = (instance, message, queueName, transactionId, source) => {
+const assertSendPromise = (instance, message, queueName, transactionId, source, routeKey) => {
 
     const options = {
         transactionId,
-        source
+        source,
+        routeKey
     };
 
     return instance.send(message, queueName, options)
@@ -33,6 +34,14 @@ const assertSendPromise = (instance, message, queueName, transactionId, source) 
 
             if (source) {
                 expect(payload.properties.headers.source).to.be.equal(source);
+            }
+
+            if (routeKey) {
+                expect(payload.properties.headers.routeKey).to.be.equal(routeKey);
+            }
+
+            if (message.event) {
+                expect(payload.properties.headers.routeKey).to.be.equal(message.event);
             }
 
             return instance.channel.ack(payload);

--- a/test/integration-callback.js
+++ b/test/integration-callback.js
@@ -290,6 +290,7 @@ describe('positive integration tests - Callback api', () => {
 
         const queueName = 'test-send-queue-1';
         const message = { name : 'bunnybus' };
+        const messageWithEvent = { event : 'event1', name : 'bunnybus' };
 
         beforeEach((done) => {
 
@@ -303,17 +304,27 @@ describe('positive integration tests - Callback api', () => {
 
         it('should send message', (done) => {
 
-            Assertions.assertSend(instance, message, queueName, null, null, done);
+            Assertions.assertSend(instance, message, queueName, null, null, null, done);
         });
 
         it('should proxy `source` when supplied', (done) => {
 
-            Assertions.assertSend(instance, message, queueName, null, 'someModule', done);
+            Assertions.assertSend(instance, message, queueName, null, 'someModule', null, done);
         });
 
         it('should proxy `transactionId` when supplied', (done) => {
 
-            Assertions.assertSend(instance, message, queueName, 'someTransactionId', null, done);
+            Assertions.assertSend(instance, message, queueName, 'someTransactionId', null, null, done);
+        });
+
+        it('should proxy `routeKey` when supplied', (done) => {
+
+            Assertions.assertSend(instance, message, queueName, null, null, 'event1', done);
+        });
+
+        it('should proxy `routeKey` when supplied', (done) => {
+
+            Assertions.assertSend(instance, messageWithEvent, queueName, null, null, null, done);
         });
     });
 

--- a/test/integration-promise.js
+++ b/test/integration-promise.js
@@ -252,6 +252,7 @@ describe('positive integration tests - Promise api', () => {
 
         const queueName = 'test-send-queue-1';
         const message = { name : 'bunnybus' };
+        const messageWithEvent = { event : 'event1', name : 'bunnybus' };
 
         beforeEach(() => {
 
@@ -265,17 +266,27 @@ describe('positive integration tests - Promise api', () => {
 
         it('should send message', () => {
 
-            return Assertions.assertSendPromise(instance, message, queueName, null, null);
+            return Assertions.assertSendPromise(instance, message, queueName, null, null, null);
         });
 
         it('should proxy `source` when supplied', () => {
 
-            return Assertions.assertSendPromise(instance, message, queueName, null, 'someModule');
+            return Assertions.assertSendPromise(instance, message, queueName, null, 'someModule', null);
         });
 
         it('should proxy `transactionId` when supplied', () => {
 
-            return Assertions.assertSendPromise(instance, message, queueName, 'someTransactionId', null);
+            return Assertions.assertSendPromise(instance, message, queueName, 'someTransactionId', null, null);
+        });
+
+        it('should proxy `routeKey` when supplied', (done) => {
+
+            return Assertions.assertSendPromise(instance, message, queueName, null, null, 'event1', done);
+        });
+
+        it('should proxy `routeKey` when supplied', (done) => {
+
+            return Assertions.assertSendPromise(instance, messageWithEvent, queueName, null, null, null, done);
         });
     });
 


### PR DESCRIPTION
## Description
When `routeKey` is available either through the `message` or `options`, it should be supplied as part of the `payload.properties.headers`.  

## Motivation and Context
When `routeKey` is available within the `payload.properties.headers`, it is easier to identify addressing with.  

## Types of changes
- [ ] Documentation only (no changes to either `lib/` or `test/` files)
- [ ] Bug fix (non-breaking change which fixes an issue. you didn't modify existing tests)
- [x] New feature (non-breaking change which adds functionality. you added at least one new test)
- [ ] Breaking change (fix or feature that would cause existing functionality to change. you had to modify existing tests.)

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/xogroup/bunnybus/blob/master/.github/CONTRIBUTING.md) document.
- [x] My code follows the [Hapi.js style guide](https://github.com/hapijs/contrib/blob/master/Style.md).
- [x] I have updated the documentation as needed.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.