### PR TITLE
Fix for amqplib connection unhappy path timeout

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -470,53 +470,55 @@ class BunnyBus extends EventEmitter{
                     queue,
                     (payload) => {
 
-                        $.logger.trace(payload);
+                        if (payload) {
+                            $.logger.trace(payload);
 
-                        const parsedPayload = Helpers.parsePayload(payload);
-                        const routeKey = Helpers.reduceRouteKey(payload, null, parsedPayload.message);
-                        const currentRetryCount = payload.properties.headers.retryCount || -1;
-                        const errorQueue = `${queue}_error`;
+                            const parsedPayload = Helpers.parsePayload(payload);
+                            const routeKey = Helpers.reduceRouteKey(payload, null, parsedPayload.message);
+                            const currentRetryCount = payload.properties.headers.retryCount || -1;
+                            const errorQueue = `${queue}_error`;
 
-                        // check for semver first
-                        if (handlers.hasOwnProperty(routeKey)) {
-                            if (!(payload.properties && payload.properties.headers && payload.properties.headers.bunnyBus)) {
-                                $.logger.warn('message not of BunnyBus origin');
-                                // should reject with error
-                                $._reject(payload, errorQueue);
-                            }
-                            else if (!Helpers.isMajorCompatible(payload.properties.headers.bunnyBus)) {
-                                $.logger.warn(`message came from older bunnyBus version (${payload.properties.headers.bunnyBus})`);
-                                // should reject with error
-                                $._reject(payload, errorQueue);
-                            }
-                            else if (currentRetryCount < maxRetryCount) {
-                                if (meta) {
-                                    handlers[routeKey](
-                                        parsedPayload.message,
-                                        parsedPayload.metaData,
-                                        $._ack.bind(null, payload),
-                                        $._reject.bind(null, payload, errorQueue),
-                                        $._requeue.bind(null, payload, queue, { routeKey })
-                                    );
+                            // check for semver first
+                            if (handlers.hasOwnProperty(routeKey)) {
+                                if (!(payload.properties && payload.properties.headers && payload.properties.headers.bunnyBus)) {
+                                    $.logger.warn('message not of BunnyBus origin');
+                                    // should reject with error
+                                    $._reject(payload, errorQueue);
+                                }
+                                else if (!Helpers.isMajorCompatible(payload.properties.headers.bunnyBus)) {
+                                    $.logger.warn(`message came from older bunnyBus version (${payload.properties.headers.bunnyBus})`);
+                                    // should reject with error
+                                    $._reject(payload, errorQueue);
+                                }
+                                else if (currentRetryCount < maxRetryCount) {
+                                    if (meta) {
+                                        handlers[routeKey](
+                                            parsedPayload.message,
+                                            parsedPayload.metaData,
+                                            $._ack.bind(null, payload),
+                                            $._reject.bind(null, payload, errorQueue),
+                                            $._requeue.bind(null, payload, queue, { routeKey })
+                                        );
+                                    }
+                                    else {
+                                        handlers[routeKey](
+                                            parsedPayload.message,
+                                            $._ack.bind(null, payload),
+                                            $._reject.bind(null, payload, errorQueue),
+                                            $._requeue.bind(null, payload, queue)
+                                        );
+                                    }
                                 }
                                 else {
-                                    handlers[routeKey](
-                                        parsedPayload.message,
-                                        $._ack.bind(null, payload),
-                                        $._reject.bind(null, payload, errorQueue),
-                                        $._requeue.bind(null, payload, queue)
-                                    );
+                                    $.logger.warn(`message passed retry limit of ${maxRetryCount} for routeKey (${routeKey})`);
+                                    // should reject with error
+                                    $._reject(payload, errorQueue);
                                 }
                             }
                             else {
-                                $.logger.warn(`message passed retry limit of ${maxRetryCount} for routeKey (${routeKey})`);
-                                // should reject with error
-                                $._reject(payload, errorQueue);
+                                $.logger.warn(`message consumed with no matching routeKey (${routeKey}) handler`);
+                                $.channel.ack(payload);
                             }
-                        }
-                        else {
-                            $.logger.warn(`message consumed with no matching routeKey (${routeKey}) handler`);
-                            $.channel.ack(payload);
                         }
                     },
                     null,
@@ -749,7 +751,14 @@ class BunnyBus extends EventEmitter{
                 $._state.connectionSemaphore = 0;
                 cb();
             }
-        ], callback);
+        ], (err) => {
+
+            if (err) {
+                $._state.connectionSemaphore = 0;
+            }
+
+            callback(err);
+        });
     }
 
     _closeConnection(callback) {
@@ -846,7 +855,14 @@ class BunnyBus extends EventEmitter{
                     cb(err);
                 });
             }
-        ], callback);
+        ], (err) => {
+
+            if (err) {
+                $._state.channelSemaphore = 0;
+            }
+
+            callback(err);
+        });
     }
 
     _closeChannel(callback) {

--- a/test/integration-edge-case.js
+++ b/test/integration-edge-case.js
@@ -27,6 +27,7 @@ describe('positive integration tests - Callback api', () => {
 
         beforeEach((done) => {
 
+            instance.config = BunnyBus.DEFAULT_SERVER_CONFIGURATION;
             instance._closeConnection(done);
         });
 
@@ -46,7 +47,7 @@ describe('positive integration tests - Callback api', () => {
             });
         });
 
-        it('should pass when get pushes a message to a subscribed queue', (done) => {
+        it('should pass when send pushes a message to a subscribed queue', (done) => {
 
             const message = { event : 'ea', name : 'bunnybus' };
             const queueName = 'edge-case-get-to-subscribe';
@@ -55,7 +56,7 @@ describe('positive integration tests - Callback api', () => {
                 ea : (subscribedMessaged, ack) => {
 
                     expect(subscribedMessaged).to.be.equal(message);
-                    resolve();
+                    ack(resolve);
                 }
             };
             const resolve = () => {
@@ -72,6 +73,24 @@ describe('positive integration tests - Callback api', () => {
                 (cb) => instance.subscribe(queueName, handlers, cb),
                 (cb) => instance.deleteQueue(queueName, cb)
             ], resolve);
+        });
+
+        it('should pass when server host configuration value is not valid', (done) => {
+
+            const message = { event : 'eb', name : 'bunnybus' };
+            instance.config = { server : 'fake' };
+
+            instance
+                .publish(message)
+                .catch(() => {
+
+                    // re-up with default configs
+                    instance.config = BunnyBus.DEFAULT_SERVER_CONFIGURATION;
+
+                    return instance
+                        .publish(message)
+                        .then(done);
+                });
         });
     });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* For both the `createConnection` and `createChannel` logic, the unhappy path when the `amqplib` returns with `err` populated, the semaphore counter for the respective resource was not reset causing future connection and channel resolutions to hang.
* When a channnel + queue is consumed and the queue is being deleted, a `null` payload is send down the `consume` RPC call.  Logic needed to be put in place to account for `null` payloads to not act.
* Also adjusted the test name.

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

* #64 

## Motivation and Context
Fix all them bugs!

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Documentation only (no changes to either `lib/` or `test/` files)
- [x] Bug fix (non-breaking change which fixes an issue. you didn't modify existing tests)
- [ ] New feature (non-breaking change which adds functionality. you added at least one new test)
- [ ] Breaking change (fix or feature that would cause existing functionality to change. you had to modify existing tests.)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/xogroup/bunnybus/blob/master/.github/CONTRIBUTING.md) document.
- [x] My code follows the [Hapi.js style guide](https://github.com/hapijs/contrib/blob/master/Style.md).
- [ ] I have updated the documentation as needed.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.