### PR TITLE
added feature to override subscribe safe guards and fixed minor bugs

### DIFF
--- a/API.md
+++ b/API.md
@@ -138,6 +138,7 @@ Setter and Getter for singleton configuration. Accepts the following optional pr
  * `port` - value of the port for client connections.  Used in the conneciton string.  Defaults to `5672`. *[number]* **Optional**
  * `vhost` - value of the virtual host the user connects to.  Used in the connection string.  Defaults to `%2f`. *[string]* **Optional**
  * `heartbeat` -  value negotiated between client and server on when the TCP tunnel is considered dead.  Unit is a measurement of milliseconds.  Used in the connection string.  Defaults to `2000`. *[number]* **Optional**
+ * `timeout` - value for timing out any network operations.  Unit is a measurement of milliseconds.  Defaults to `500`. *[number]* **Optional**
  * `globalExchange` - value of the exchange to transact through for message publishing.  This is the default used when one is not provided within the `options` for any `BunnyBus` methods that supports one transactionally.  Defaults to `default-exchange`. *[string]* **Optional**
  * `prefetch` - value of the maximum number of unacknowledged messages allowable in a channel.  Defaults to `5`. *[number]* **Optional**
  * `maxRetryCount` - maximum amount of attempts a message can be requeued.  This is the default used when one is not provided within the `options` for any `BunnyBus` methods that supports one transactionally. Defaults to `10`. *[number]* **Optional**

--- a/API.md
+++ b/API.md
@@ -141,6 +141,8 @@ Setter and Getter for singleton configuration. Accepts the following optional pr
  * `globalExchange` - value of the exchange to transact through for message publishing.  This is the default used when one is not provided within the `options` for any `BunnyBus` methods that supports one transactionally.  Defaults to `default-exchange`. *[string]* **Optional**
  * `prefetch` - value of the maximum number of unacknowledged messages allowable in a channel.  Defaults to `5`. *[number]* **Optional**
  * `maxRetryCount` - maximum amount of attempts a message can be requeued.  This is the default used when one is not provided within the `options` for any `BunnyBus` methods that supports one transactionally. Defaults to `10`. *[number]* **Optional**
+ * `validatePublisher` - flag to dictate if consuming messages should be validated for a signature of publishing source.  This is a safe guard to prevent unexpected message sources from entering the subscribing realm. A value of `bunnyBus` is stamped as a header property on the message during `publish()`.  The `subscribe()` method will use the same value for authentication.  Defaults to `true`. *[boolean]* **Optional**
+ * `validateVersion` - flag to dictate if major semver should be matched as part of the message subscription valiation.  This is a safe guard to prevent mismatched `bunnyBus` drivers from pub/sub to each other.  Consumers detecting mismatched major values will auto reject the message into an error queue.  In order for this layer of validation to occur, `validatePublisher` must be allowed because the version value is set against the `bunnyBus` header.   Defaults to `true`. *[boolean]* **Optional**
 
 Note that updates in the options directed at changing connection string will not take affect immediately.  [`_closeConnection()`](#_closeConnectioncallback) needs to be called manually to invoke a new connection with new settings.
 
@@ -452,6 +454,8 @@ Subscribe to messages from the queue.
     - `queue` - settings for the queue. [Settings](http://www.squaremobius.net/amqp.node/channel_api.html#channel_assertQueue) are proxied through to amqplib `assertQueue`. *[Object]* **Optional**
     - `globalExchange` - value of the exchange to transact through for message publishing.  Defaults to one provided in the [config](#config). *[string]* **Optional**
     - `maxRetryCount` - maximum amount of attempts a message can be requeued.  Defaults to one provided in the [config](#config). *[number]* **Optional**
+    - `validatePublisher` - flag for validating messages having `bunnyBus` header.  More info can be found in [config](#config). Defaults to one provided in the [config](#config). *[boolean]* **Optional**
+    - `validateVersion` - flag for validating messages generated from the same major version.  More info can be found in [config](#config). Defaults to one provided in the [config](#config). *[boolean]* **Optional**
     - `meta` - allows for meta data regarding the payload to be returned.  Turning this on will adjust the handler to be a `Function` as `(message, meta, [ack, [reject, [requeue]]]) => {}`. *[boolean]* **Optional**
   - `callback` - node style callback `(err, result) => {}`. *[Function]* **Optional**
 

--- a/lib/helpers/cleanObject.js
+++ b/lib/helpers/cleanObject.js
@@ -3,7 +3,7 @@
 const cleanObject = (obj) => {
 
     for (const key in obj) {
-        if (!obj[key]) {
+        if (obj[key] === undefined || obj[key] === null) {
             delete obj[key];
         }
         else if (obj[key] instanceof Object) {

--- a/lib/helpers/defaultConfiguration.js
+++ b/lib/helpers/defaultConfiguration.js
@@ -14,7 +14,9 @@ module.exports = {
         prefetch           : 5,
         errorQueue         : 'error-bus',
         silence            : false,
-        maxRetryCount      : 10
+        maxRetryCount      : 10,
+        validatePublisher  : true,
+        validateVersion    : true
     },
     queue : {
         exclusive : false,

--- a/lib/helpers/defaultConfiguration.js
+++ b/lib/helpers/defaultConfiguration.js
@@ -9,6 +9,7 @@ module.exports = {
         port               : 5672,
         vhost              : '%2f',
         heartbeat          : 2000,
+        timeout            : 500,
         autoAcknowledgement: false,
         globalExchange     : 'default-exchange',
         prefetch           : 5,

--- a/lib/index.js
+++ b/lib/index.js
@@ -788,7 +788,7 @@ class BunnyBus extends EventEmitter{
 
                 if (!$.hasConnection) {
 
-                    Async.timeout(Amqp.connect,500)($.connectionString, cb);
+                    Async.timeout(Amqp.connect,$.config.timeout)($.connectionString, cb);
                 }
                 else {
                     cb(null, $.connection);

--- a/lib/index.js
+++ b/lib/index.js
@@ -491,6 +491,8 @@ class BunnyBus extends EventEmitter{
         const queueOptions = options && options.queue ? options.queue : null;
         const globalExchange = (options && options.globalExchange) || $.config.globalExchange;
         const maxRetryCount = (options && options.maxRetryCount) || $.config.maxRetryCount;
+        const validatePublisher = (options && options.hasOwnProperty('validatePublisher')) ? options.validatePublisher : $.config.validatePublisher;
+        const validateVersion = (options && options.hasOwnProperty('validateVersion')) ? options.validateVersion : $.config.validateVersion;
         const meta = (options && options.meta);
 
         Async.auto({
@@ -526,14 +528,15 @@ class BunnyBus extends EventEmitter{
                             const currentRetryCount = payload.properties.headers.retryCount || -1;
                             const errorQueue = `${queue}_error`;
 
-                            // check for semver first
                             if (handlers.hasOwnProperty(routeKey)) {
-                                if (!(payload.properties && payload.properties.headers && payload.properties.headers.bunnyBus)) {
+                                // check for `bunnyBus` header first
+                                if (validatePublisher && !(payload.properties && payload.properties.headers && payload.properties.headers.bunnyBus)) {
                                     $.logger.warn('message not of BunnyBus origin');
                                     // should reject with error
                                     $._reject(payload, errorQueue);
                                 }
-                                else if (!Helpers.isMajorCompatible(payload.properties.headers.bunnyBus)) {
+                                // check for `bunnyBus`:<version> semver
+                                else if (validatePublisher && validateVersion && !Helpers.isMajorCompatible(payload.properties.headers.bunnyBus)) {
                                     $.logger.warn(`message came from older bunnyBus version (${payload.properties.headers.bunnyBus})`);
                                     // should reject with error
                                     $._reject(payload, errorQueue);
@@ -784,7 +787,8 @@ class BunnyBus extends EventEmitter{
             (cb) => {
 
                 if (!$.hasConnection) {
-                    Amqp.connect($.connectionString, cb);
+
+                    Async.timeout(Amqp.connect,500)($.connectionString, cb);
                 }
                 else {
                     cb(null, $.connection);

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -123,6 +123,24 @@ describe('helpers', () => {
 
             done();
         });
+
+        it('should not clean properties that are false', (done) => {
+
+            const obj = {
+                a : 'value1',
+                b : true,
+                c : false,
+                d : undefined
+            };
+
+            Helpers.cleanObject(obj);
+
+            const cleanedKeys = Object.keys(obj);
+
+            expect(cleanedKeys.find((key) => key === 'd')).to.be.undefined();
+
+            done();
+        });
     });
 
     describe('convertToBuffer', () => {

--- a/test/integration-edge-case.js
+++ b/test/integration-edge-case.js
@@ -80,17 +80,17 @@ describe('positive integration tests - Callback api', () => {
             const message = { event : 'eb', name : 'bunnybus' };
             instance.config = { server : 'fake' };
 
-            instance
-                .publish(message)
-                .catch(() => {
+            instance.publish(message, (err) => {
 
-                    // re-up with default configs
+                if (err) {
                     instance.config = BunnyBus.DEFAULT_SERVER_CONFIGURATION;
 
-                    return instance
-                        .publish(message)
-                        .then(done);
-                });
+                    instance.publish(message, done);
+                }
+                else {
+                    done(new Error('fake configuration took'));
+                }
+            });
         });
     });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added two flags `validatePublisher` and `validateVersion` to allow for overriding of safe guards within the subscriber end to skip checking of publisher signature and matching major version of publishing agent.

Also found a bug within `Helpers.cleanObject()` function where it was unintentionally wiping properties with values set to `false` because of truthy check.  Replaced this with a more rigorous type check against `undefined` and `null`.  

Updated one of the test in the callback suite to a callback structure from a Promise based structure to align with the intent of the test file.

A timeout bug was found through one of the edge case automation test where a connection made to a non-existent server took too long (60s >) to time out.  Timeout code wrapper around the connection logic has been added to provide for shorter timeout periods.

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

* #68 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Documentation only (no changes to either `lib/` or `test/` files)
- [x] Bug fix (non-breaking change which fixes an issue. you didn't modify existing tests)
- [x] New feature (non-breaking change which adds functionality. you added at least one new test)
- [ ] Breaking change (fix or feature that would cause existing functionality to change. you had to modify existing tests.)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/xogroup/bunnybus/blob/master/.github/CONTRIBUTING.md) document.
- [x] My code follows the [Hapi.js style guide](https://github.com/hapijs/contrib/blob/master/Style.md).
- [x] I have updated the documentation as needed.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.