### PR TITLE
71 connection close handling

### DIFF
--- a/API.md
+++ b/API.md
@@ -88,9 +88,15 @@
   - [`BunnyBus.AMQP_CONNECTION_ERROR_EVENT`](#bunnybusamqp_connection_error_event)
     - [event key](#event-key-11)
     - [handler parameter(s)](#handler-parameters-9)
-  - [`BunnyBus.AMQP_CHANNEL_ERROR_EVENT`](#bunnybusamqp_channel_error_event)
+  - [`BunnyBus.AMQP_CONNECTION_CLOSE_EVENT`](#bunnybusamqp_connection_close_event)
     - [event key](#event-key-12)
     - [handler parameter(s)](#handler-parameters-10)
+  - [`BunnyBus.AMQP_CHANNEL_ERROR_EVENT`](#bunnybusamqp_channel_error_event)
+    - [event key](#event-key-13)
+    - [handler parameter(s)](#handler-parameters-11)
+  - [`BunnyBus.AMQP_CHANNEL_CLOSE_EVENT`](#bunnybusamqp_channel_close_event)
+    - [event key](#event-key-14)
+    - [handler parameter(s)](#handler-parameters-12)
 - [`SubscriptionManager`](#subscriptionmanager)
   - [`contains(queue, [withConsumerTag])`](#containsqueue-withconsumertag)
   - [`create(queue, handlers, [options])`](#createqueue-handlers-options)
@@ -925,7 +931,7 @@ bunnyBus.on('BunnyBus.RECOVERED_EVENT', () => {
 
 #### event key
 
-* `amqp.connection.error'` - emitted when amqplib encounters a corrupted connection state.
+* `amqp.connection.error` - emitted when amqplib encounters a corrupted connection state.
 
 #### handler parameter(s)
 
@@ -940,11 +946,30 @@ bunnyBus.on('BunnyBus.AMQP_CONNECTION_ERROR_EVENT', (err) => {
 });
 ```
 
+### `BunnyBus.AMQP_CONNECTION_CLOSE_EVENT`
+
+#### event key
+
+* `amqp.connection.close` - emitted when amqplib connection closes.
+
+#### handler parameter(s)
+
+* `err` - error from amqplib. *[Object]*
+
+```Javascript
+const BunnyBus = require('bunnybus');
+
+bunnyBus.on('BunnyBus.AMQP_CONNECTION_CLOSE_EVENT', (err) => {
+
+    // do work
+});
+```
+
 ### `BunnyBus.AMQP_CHANNEL_ERROR_EVENT`
 
 #### event key
 
-* `amqp.channel.error'` - emitted when amqplib encounters a corrupted channel state.
+* `amqp.channel.error` - emitted when amqplib encounters a corrupted channel state.
 
 #### handler parameter(s)
 
@@ -954,6 +979,25 @@ bunnyBus.on('BunnyBus.AMQP_CONNECTION_ERROR_EVENT', (err) => {
 const BunnyBus = require('bunnybus');
 
 bunnyBus.on('BunnyBus.AMQP_CHANNEL_ERROR_EVENT', (err) => {
+
+    // do work
+});
+```
+
+### `BunnyBus.AMQP_CHANNEL_CLOSE_EVENT`
+
+#### event key
+
+* `amqp.channel.close` - emitted when amqplib channel closes.
+
+#### handler parameter(s)
+
+* `err` - error from amqplib. *[Object]*
+
+```Javascript
+const BunnyBus = require('bunnybus');
+
+bunnyBus.on('BunnyBus.AMQP_CHANNEL_CLOSE_EVENT', (err) => {
 
     // do work
 });

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,7 +8,9 @@ const Exceptions = require('./exceptions');
 const SubscriptionManager = require('./states').SubscriptionManager;
 const EventLogger = require('./loggers').EventLogger;
 const AMQP_CONNECTION_ERROR_EVENT = 'error';
+const AMQP_CONNECTION_CLOSE_EVENT = 'close';
 const AMQP_CHANNEL_ERROR_EVENT = 'error';
+const AMQP_CHANNEL_CLOSE_EVENT = 'close';
 const internals = {
     handlers : {}
 };
@@ -26,6 +28,8 @@ class BunnyBus extends EventEmitter{
 
             $._state = {
                 recovery            : false,
+                activeConnection    : false,
+                activeChannel       : false,
                 connectionSemaphore : 0,
                 channelSemaphore    : 0
             };
@@ -115,9 +119,19 @@ class BunnyBus extends EventEmitter{
         return 'amqp.connection.error';
     }
 
+    static get AMQP_CONNECTION_CLOSE_EVENT() {
+        
+        return 'amqp.connection.close';
+    }
+
     static get AMQP_CHANNEL_ERROR_EVENT() {
 
         return 'amqp.channel.error';
+    }
+
+    static get AMQP_CHANNEL_CLOSE_EVENT() {
+
+        return 'amqp.channel.close';
     }
 
     get config() {
@@ -173,6 +187,7 @@ class BunnyBus extends EventEmitter{
 
         if (value) {
             value.on(AMQP_CONNECTION_ERROR_EVENT, internals.handlers[BunnyBus.AMQP_CONNECTION_ERROR_EVENT]);
+            value.on(AMQP_CONNECTION_CLOSE_EVENT, internals.handlers[BunnyBus.AMQP_CONNECTION_CLOSE_EVENT]);
         }
 
         $._connection = value;
@@ -192,6 +207,7 @@ class BunnyBus extends EventEmitter{
 
         if (value) {
             value.on(AMQP_CHANNEL_ERROR_EVENT, internals.handlers[BunnyBus.AMQP_CHANNEL_ERROR_EVENT]);
+            value.on(AMQP_CHANNEL_CLOSE_EVENT, internals.handlers[BunnyBus.AMQP_CHANNEL_CLOSE_EVENT]);
         }
 
         $._channel = value;
@@ -752,6 +768,8 @@ class BunnyBus extends EventEmitter{
 
     _createConnection(callback)  {
 
+        $._state.activeConnection = true;
+
         callback = Helpers.reduceCallback(callback);
 
         if (callback === undefined) {
@@ -811,6 +829,8 @@ class BunnyBus extends EventEmitter{
 
     _closeConnection(callback) {
 
+        $._state.activeConnection = false;
+
         callback = Helpers.reduceCallback(callback);
 
         if (callback === undefined) {
@@ -843,6 +863,8 @@ class BunnyBus extends EventEmitter{
     }
 
     _createChannel(callback) {
+
+        $._state.activeChannel = true;
 
         callback = Helpers.reduceCallback(callback);
 
@@ -915,6 +937,8 @@ class BunnyBus extends EventEmitter{
 
     _closeChannel(callback) {
 
+        $._state.activeChannel = false;
+
         callback = Helpers.reduceCallback(callback);
 
         if (callback === undefined) {
@@ -962,20 +986,45 @@ internals.handlers[SubscriptionManager.UNBLOCKED_EVENT] = (queue) => {
 };
 
 internals.handlers[BunnyBus.AMQP_CONNECTION_ERROR_EVENT] = (err) => {
-
-    $.logger.error('connection errored');
+console.log('connection errored');
+    
     $.emit(BunnyBus.AMQP_CONNECTION_ERROR_EVENT, err);
     $.connection = null;
     $.channel = null;
+    $.logger.error('connection errored');
     $._recoverConnectChannel();
 };
 
-internals.handlers[BunnyBus.AMQP_CHANNEL_ERROR_EVENT] = (err) => {
+internals.handlers[BunnyBus.AMQP_CONNECTION_CLOSE_EVENT] = (err) => {
+    console.log('connection closed');
+    $.emit(BunnyBus.AMQP_CONNECTION_CLOSE_EVENT, err);
+    $.connection = null;
+    $.channel = null;
 
-    $.logger.error('channel errored');
+    if ($._state.activeConnection) {
+        $.logger.error('connection closed');
+        $._recoverConnectChannel();
+    }
+};
+
+internals.handlers[BunnyBus.AMQP_CHANNEL_ERROR_EVENT] = (err) => {
+    console.log('channel errored');
     $.emit(BunnyBus.AMQP_CHANNEL_ERROR_EVENT, err);
     $.channel = null;
+    $.logger.error('channel errored');
     $._recoverConnectChannel();
+};
+
+internals.handlers[BunnyBus.AMQP_CHANNEL_CLOSE_EVENT] = (err) => {
+    console.log('channel closed');
+    
+    $.emit(BunnyBus.AMQP_CHANNEL_CLOSE_EVENT, err);
+    $.channel = null;
+
+    if ($._state.activeChannel && $._state.activeConnection) {
+        $.logger.error('channel closed');
+        $._recoverConnectChannel();
+    }
 };
 
 module.exports = BunnyBus;

--- a/lib/index.js
+++ b/lib/index.js
@@ -120,7 +120,7 @@ class BunnyBus extends EventEmitter{
     }
 
     static get AMQP_CONNECTION_CLOSE_EVENT() {
-        
+
         return 'amqp.connection.close';
     }
 
@@ -990,8 +990,7 @@ internals.handlers[SubscriptionManager.UNBLOCKED_EVENT] = (queue) => {
 };
 
 internals.handlers[BunnyBus.AMQP_CONNECTION_ERROR_EVENT] = (err) => {
-console.log('connection errored');
-    
+
     $.emit(BunnyBus.AMQP_CONNECTION_ERROR_EVENT, err);
     $.connection = null;
     $.channel = null;
@@ -1000,7 +999,7 @@ console.log('connection errored');
 };
 
 internals.handlers[BunnyBus.AMQP_CONNECTION_CLOSE_EVENT] = (err) => {
-    console.log('connection closed');
+
     $.emit(BunnyBus.AMQP_CONNECTION_CLOSE_EVENT, err);
     $.connection = null;
     $.channel = null;
@@ -1012,7 +1011,7 @@ internals.handlers[BunnyBus.AMQP_CONNECTION_CLOSE_EVENT] = (err) => {
 };
 
 internals.handlers[BunnyBus.AMQP_CHANNEL_ERROR_EVENT] = (err) => {
-    console.log('channel errored');
+
     $.emit(BunnyBus.AMQP_CHANNEL_ERROR_EVENT, err);
     $.channel = null;
     $.logger.error('channel errored');
@@ -1020,8 +1019,7 @@ internals.handlers[BunnyBus.AMQP_CHANNEL_ERROR_EVENT] = (err) => {
 };
 
 internals.handlers[BunnyBus.AMQP_CHANNEL_CLOSE_EVENT] = (err) => {
-    console.log('channel closed');
-    
+
     $.emit(BunnyBus.AMQP_CHANNEL_CLOSE_EVENT, err);
     $.channel = null;
 

--- a/test/integration-edge-case.js
+++ b/test/integration-edge-case.js
@@ -75,7 +75,7 @@ describe('positive integration tests - Callback api', () => {
             ], resolve);
         });
 
-        it.only('should pass when server host configuration value is not valid', (done) => {
+        it('should pass when server host configuration value is not valid', (done) => {
 
             const message = { event : 'eb', name : 'bunnybus' };
             instance.config = { server : 'fake' };

--- a/test/integration-edge-case.js
+++ b/test/integration-edge-case.js
@@ -75,7 +75,7 @@ describe('positive integration tests - Callback api', () => {
             ], resolve);
         });
 
-        it('should pass when server host configuration value is not valid', (done) => {
+        it.only('should pass when server host configuration value is not valid', (done) => {
 
             const message = { event : 'eb', name : 'bunnybus' };
             instance.config = { server : 'fake' };

--- a/test/integration-events.js
+++ b/test/integration-events.js
@@ -1,4 +1,3 @@
-
 'use strict';
 
 const Async = require('async');
@@ -28,16 +27,37 @@ describe('positive integration tests - events', () => {
 
     describe('recovering', () =>  {
 
-        before((done) => {
+        beforeEach((done) => {
 
             instance._autoConnectChannel(done);
         });
 
-        it('should be evented when connection is recovering', (done) => {
+        it('should be evented when connection was errored and is recovering', (done) => {
 
             instance.once(BunnyBus.RECOVERING_EVENT, done);
 
             instance.connection.emit('error');
+        });
+
+        it('should be evented when channel was errored and is recovering', (done) => {
+
+            instance.once(BunnyBus.RECOVERING_EVENT, done);
+
+            instance.channel.emit('error');
+        });
+
+        it('should be evented when connection was closed and is recovering', (done) => {
+
+            instance.once(BunnyBus.RECOVERING_EVENT, done);
+
+            instance.connection.emit('close');
+        });
+
+        it('should be evented when channel was closed and is recovering', (done) => {
+
+            instance.once(BunnyBus.RECOVERING_EVENT, done);
+
+            instance.channel.emit('close');
         });
     });
 
@@ -48,11 +68,32 @@ describe('positive integration tests - events', () => {
             instance._autoConnectChannel(done);
         });
 
-        it('should be evented when connection is recovering', (done) => {
+        it('should be evented when connection was errored and is recovering', (done) => {
 
             instance.once(BunnyBus.RECOVERED_EVENT, done);
 
             instance.connection.emit('error');
+        });
+
+        it('should be evented when channel was errored and is recovering', (done) => {
+
+            instance.once(BunnyBus.RECOVERED_EVENT, done);
+
+            instance.channel.emit('error');
+        });
+
+        it('should be evented when connection was closed and is recovering', (done) => {
+
+            instance.once(BunnyBus.RECOVERED_EVENT, done);
+
+            instance.connection.emit('close');
+        });
+
+        it('should be evented when channel was closed and is recovering', (done) => {
+
+            instance.once(BunnyBus.RECOVERED_EVENT, done);
+
+            instance.channel.emit('close');
         });
     });
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added `close` event handling for the native amqp `connection` and `channel` objects.  Also exposed new `bunnyBus` events to represent them similar to the existing error events.

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

- #71 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Want to make sure `bunnybus` would recover from any unexpected network or server side closed actions. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Documentation only (no changes to either `lib/` or `test/` files)
- [x] Bug fix (non-breaking change which fixes an issue. you didn't modify existing tests)
- [ ] New feature (non-breaking change which adds functionality. you added at least one new test)
- [ ] Breaking change (fix or feature that would cause existing functionality to change. you had to modify existing tests.)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/xogroup/bunnybus/blob/master/.github/CONTRIBUTING.md) document.
- [x] My code follows the [Hapi.js style guide](https://github.com/hapijs/contrib/blob/master/Style.md).
- [x] I have updated the documentation as needed.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.