### PR TITLE
62 consumer route pattern matching

### DIFF
--- a/lib/helpers/handlerMatcher.js
+++ b/lib/helpers/handlerMatcher.js
@@ -1,0 +1,18 @@
+'use strict';
+const RouteMatcher = require('./routeMatcher');
+
+const handlerMatcher = (handlers, match) => {
+
+    const result = [];
+
+    for (const key in handlers) {
+
+        if (RouteMatcher(key, match)) {
+            result.push(handlers[key]);
+        }
+    }
+
+    return result;
+};
+
+module.exports = handlerMatcher;

--- a/lib/helpers/index.js
+++ b/lib/helpers/index.js
@@ -13,5 +13,6 @@ module.exports = {
     reduceCallback         : require('./reduceCallback'),
     validateLoggerContract : require('./validateLoggerContract'),
     validatePromiseContract: require('./validatePromiseContract'),
+    routeMatcher           : require('./routeMatcher'),
     toPromise              : require('./toPromise')
 };

--- a/lib/helpers/index.js
+++ b/lib/helpers/index.js
@@ -14,5 +14,6 @@ module.exports = {
     validateLoggerContract : require('./validateLoggerContract'),
     validatePromiseContract: require('./validatePromiseContract'),
     routeMatcher           : require('./routeMatcher'),
+    handlerMatcher         : require('./handlerMatcher'),
     toPromise              : require('./toPromise')
 };

--- a/lib/helpers/routeMatcher.js
+++ b/lib/helpers/routeMatcher.js
@@ -1,0 +1,36 @@
+'use strict';
+
+const regexPatternLookup = {};
+const regexTokenLookup = {};
+regexTokenLookup['*'] = '[\\d\\w*#]*';
+regexTokenLookup['#'] = '[\\d\\w.*#]*';
+
+const routeMatcher = (pattern, match) => {
+
+    let regex = regexPatternLookup[pattern];
+
+    if (!regex) {
+        const regexPattern = [];
+
+        regexPattern.push('^');
+
+        for (const c of pattern) {
+
+            if (regexTokenLookup[c]) {
+                regexPattern.push(regexTokenLookup[c]);
+            }
+            else {
+                regexPattern.push(c);
+            }
+        }
+
+        regexPattern.push('$');
+
+        regex = new RegExp(regexPattern.join(''));
+        regexPatternLookup[pattern] = regex;
+    }
+
+    return regex.test(match);
+};
+
+module.exports = routeMatcher;

--- a/lib/index.js
+++ b/lib/index.js
@@ -543,9 +543,9 @@ class BunnyBus extends EventEmitter{
                             const routeKey = Helpers.reduceRouteKey(payload, null, parsedPayload.message);
                             const currentRetryCount = payload.properties.headers.retryCount || -1;
                             const errorQueue = `${queue}_error`;
+                            const matchedHandlers = Helpers.handlerMatcher(handlers, routeKey);
 
-
-                            if (handlers.hasOwnProperty(routeKey)) {
+                            if (matchedHandlers.length > 0) {
                                 // check for `bunnyBus` header first
                                 if (validatePublisher && !(payload.properties && payload.properties.headers && payload.properties.headers.bunnyBus)) {
                                     $.logger.warn('message not of BunnyBus origin');
@@ -559,23 +559,26 @@ class BunnyBus extends EventEmitter{
                                     $._reject(payload, errorQueue);
                                 }
                                 else if (currentRetryCount < maxRetryCount) {
-                                    if (meta) {
-                                        handlers[routeKey]( // change this
-                                            parsedPayload.message,
-                                            parsedPayload.metaData,
-                                            $._ack.bind(null, payload),
-                                            $._reject.bind(null, payload, errorQueue),
-                                            $._requeue.bind(null, payload, queue, { routeKey })
-                                        );
-                                    }
-                                    else {
-                                        handlers[routeKey](
-                                            parsedPayload.message,
-                                            $._ack.bind(null, payload),
-                                            $._reject.bind(null, payload, errorQueue),
-                                            $._requeue.bind(null, payload, queue)
-                                        );
-                                    }
+                                    matchedHandlers.forEach((matchedHandler) => {
+
+                                        if (meta) {
+                                            matchedHandler(
+                                                parsedPayload.message,
+                                                parsedPayload.metaData,
+                                                $._ack.bind(null, payload),
+                                                $._reject.bind(null, payload, errorQueue),
+                                                $._requeue.bind(null, payload, queue, { routeKey })
+                                            );
+                                        }
+                                        else {
+                                            matchedHandler(
+                                                parsedPayload.message,
+                                                $._ack.bind(null, payload),
+                                                $._reject.bind(null, payload, errorQueue),
+                                                $._requeue.bind(null, payload, queue)
+                                            );
+                                        }
+                                    });
                                 }
                                 else {
                                     $.logger.warn(`message passed retry limit of ${maxRetryCount} for routeKey (${routeKey})`);

--- a/lib/index.js
+++ b/lib/index.js
@@ -544,6 +544,7 @@ class BunnyBus extends EventEmitter{
                             const currentRetryCount = payload.properties.headers.retryCount || -1;
                             const errorQueue = `${queue}_error`;
 
+
                             if (handlers.hasOwnProperty(routeKey)) {
                                 // check for `bunnyBus` header first
                                 if (validatePublisher && !(payload.properties && payload.properties.headers && payload.properties.headers.bunnyBus)) {
@@ -559,7 +560,7 @@ class BunnyBus extends EventEmitter{
                                 }
                                 else if (currentRetryCount < maxRetryCount) {
                                     if (meta) {
-                                        handlers[routeKey](
+                                        handlers[routeKey]( // change this
                                             parsedPayload.message,
                                             parsedPayload.metaData,
                                             $._ack.bind(null, payload),

--- a/test/assertions/assertPublish.js
+++ b/test/assertions/assertPublish.js
@@ -36,14 +36,11 @@ const assertPublish = (instance, message, queueName, routeKey, transactionId, so
 
             if (source) {
                 expect(payload.properties.headers.source).to.be.string();
+                expect(payload.properties.headers.source).to.be.equal(source);
             }
 
             if (transactionId) {
                 expect(payload.properties.headers.transactionId).to.be.equal(transactionId);
-            }
-
-            if (source) {
-                expect(payload.properties.headers.source).to.be.equal(source);
             }
 
             instance.channel.ack(payload);

--- a/test/assertions/assertPublishPromise.js
+++ b/test/assertions/assertPublishPromise.js
@@ -34,14 +34,11 @@ const assertPublishPromise = (instance, message, queueName, routeKey, transactio
 
                 if (source) {
                     expect(payload.properties.headers.source).to.be.string();
+                    expect(payload.properties.headers.source).to.be.equal(source);
                 }
 
                 if (transactionId) {
                     expect(payload.properties.headers.transactionId).to.be.equal(transactionId);
-                }
-
-                if (source) {
-                    expect(payload.properties.headers.source).to.be.equal(source);
                 }
 
                 instance.channel.ack(payload);

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -701,7 +701,7 @@ describe('helpers', () => {
         });
     });
 
-    describe.only('handlerMatcher', () => {
+    describe('handlerMatcher', () => {
 
         it('should not match any handler', (done) => {
 

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -700,4 +700,51 @@ describe('helpers', () => {
             });
         });
     });
+
+    describe.only('handlerMatcher', () => {
+
+        it('should not match any handler', (done) => {
+
+            const handlers = {
+                'abc.#.xyz' : () => {},
+                'abc.*.hello.world': () => {},
+                'abc.xyz' : () => {}
+            };
+
+            const result = Helpers.handlerMatcher(handlers, 'world.hello');
+
+            expect(result).to.be.an.array();
+            expect(result).to.have.length(0);
+            done();
+        });
+
+        it('should match a single handler', (done) => {
+
+            const handlers = {
+                'hello.world' : () => {},
+                'world.hello' : () => {}
+            };
+
+            const result = Helpers.handlerMatcher(handlers, 'world.hello');
+
+            expect(result).to.be.an.array();
+            expect(result).to.have.length(1);
+            done();
+        });
+
+        it('should match multiple handlers', (done) => {
+
+            const handlers = {
+                'abc.#.xyz' : () => {},
+                'abc.*.xyz' : () => {},
+                'abc.xyz' : () => {}
+            };
+
+            const result = Helpers.handlerMatcher(handlers, 'abc.hello.xyz');
+
+            expect(result).to.be.an.array();
+            expect(result).to.have.length(2);
+            done();
+        });
+    });
 });

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -460,4 +460,244 @@ describe('helpers', () => {
             });
         });
     });
+
+    describe('routeMatcher', () => {
+
+        describe('when binding pattern is abc.xyz', () =>  {
+
+            const pattern = 'abc.xyz';
+
+            it('should match for abc.xyz', (done) => {
+
+                expect(Helpers.routeMatcher(pattern, 'abc.xyz')).to.be.true();
+                done();
+            });
+
+            it('should not match for xyz.abc', (done) => {
+
+                expect(Helpers.routeMatcher(pattern, 'xyz.abc')).to.be.false();
+                done();
+            });
+        });
+
+        describe('when binding pattern is a.*', () => {
+
+            const pattern = 'a.*';
+
+            it('should match for a.hello', (done) => {
+
+                expect(Helpers.routeMatcher(pattern, 'a.hello')).to.be.true();
+                done();
+            });
+
+            it('should match for a.hello', (done) => {
+
+                expect(Helpers.routeMatcher(pattern, 'a.')).to.be.true();
+                done();
+            });
+
+            it('should not match for a.hello.world', (done) => {
+
+                expect(Helpers.routeMatcher(pattern, 'a.hello.world')).to.be.false();
+                done();
+            });
+        });
+
+        describe('when binding pattern is *.a', () => {
+
+            const pattern = '*.a';
+
+            it('should match for hello.a', (done) => {
+
+                expect(Helpers.routeMatcher(pattern, 'hello.a')).to.be.true();
+                done();
+            });
+
+            it('should match for .a', (done) => {
+
+                expect(Helpers.routeMatcher(pattern, '.a')).to.be.true();
+                done();
+            });
+
+            it('should not match for world.hello.a', (done) => {
+
+                expect(Helpers.routeMatcher(pattern, 'world.hello.a')).to.be.false();
+                done();
+            });
+        });
+
+        describe('when binding pattern is a.#', () => {
+
+            const pattern = 'a.#';
+
+            it('should match for a.hello', (done) => {
+
+                expect(Helpers.routeMatcher(pattern, 'a.hello')).to.be.true();
+                done();
+            });
+
+            it('should match for a.hello.world', (done) => {
+
+                expect(Helpers.routeMatcher(pattern, 'a.hello.world')).to.be.true();
+                done();
+            });
+
+            it('should match for a.', (done) => {
+
+                expect(Helpers.routeMatcher(pattern, 'a.')).to.be.true();
+                done();
+            });
+
+            it('should not match for b.a.hello.world', (done) => {
+
+                expect(Helpers.routeMatcher(pattern, 'b.a.hello.world')).to.be.false();
+                done();
+            });
+        });
+
+        describe('when binding pattern is a.*.b', () => {
+
+            const pattern = 'a.*.b';
+
+            it('should match for a.c.b', (done) => {
+
+                expect(Helpers.routeMatcher(pattern, 'a.c.b')).to.be.true();
+                done();
+            });
+
+            it('should match for a..b', (done) => {
+
+                expect(Helpers.routeMatcher(pattern, 'a..b')).to.be.true();
+                done();
+            });
+
+            it('should match for a.b', (done) => {
+
+                expect(Helpers.routeMatcher(pattern, 'a.b')).to.be.false();
+                done();
+            });
+        });
+
+        describe('when binding pattern is a.#.b', () => {
+
+            const pattern = 'a.#.b';
+
+            it('should match for a.hello.b', (done) => {
+
+                expect(Helpers.routeMatcher(pattern, 'a.hello.b')).to.be.true();
+                done();
+            });
+
+            it('should match for a.hello.world.b', (done) => {
+
+                expect(Helpers.routeMatcher(pattern, 'a.hello.world.b')).to.be.true();
+                done();
+            });
+
+            it('should not match for a.b', (done) => {
+
+                expect(Helpers.routeMatcher(pattern, 'a.b')).to.be.false();
+                done();
+            });
+
+            it('should match for a..b', (done) => {
+
+                expect(Helpers.routeMatcher(pattern, 'a..b')).to.be.true();
+                done();
+            });
+
+            it('should not match for hello.world.b', (done) => {
+
+                expect(Helpers.routeMatcher(pattern, 'hello.world.b')).to.be.false();
+                done();
+            });
+
+            it('should match for a.hello.world', (done) => {
+
+                expect(Helpers.routeMatcher(pattern, 'a.hello.world')).to.be.false();
+                done();
+            });
+        });
+
+        describe('when binding pattern is abc.#.xyz', () => {
+
+            const pattern = 'abc.#.xyz';
+
+            it('should match for abc.hello.xyz', (done) => {
+
+                expect(Helpers.routeMatcher(pattern, 'abc.hello.xyz')).to.be.true();
+                done();
+            });
+
+            it('should match for abc.hello.world.xyz', (done) => {
+
+                expect(Helpers.routeMatcher(pattern, 'abc.hello.world.xyz')).to.be.true();
+                done();
+            });
+
+            it('should match for abc..xyz', (done) => {
+
+                expect(Helpers.routeMatcher(pattern, 'abc..xyz')).to.be.true();
+                done();
+            });
+
+            it('should not match for abc.xyz', (done) => {
+
+                expect(Helpers.routeMatcher(pattern, 'abc.xyz')).to.be.false();
+                done();
+            });
+        });
+
+        describe('when binding pattern is .#.', () => {
+
+            const pattern = '.#.';
+
+            it('should match for .a.', (done) => {
+
+                expect(Helpers.routeMatcher(pattern, '.a.')).to.be.true();
+                done();
+            });
+
+            it('should match for .#.', (done) => {
+
+                expect(Helpers.routeMatcher(pattern, '.#.')).to.be.true();
+                done();
+            });
+
+            it('should match for ..', (done) => {
+
+                expect(Helpers.routeMatcher(pattern, '..')).to.be.true();
+                done();
+            });
+
+            it('should match for ....', (done) => {
+
+                expect(Helpers.routeMatcher(pattern, '....')).to.be.true();
+                done();
+            });
+        });
+
+        describe('when binding pattern is .*.', () => {
+
+            const pattern = '.#.';
+
+            it('should match for .a.', (done) => {
+
+                expect(Helpers.routeMatcher(pattern, '.a.')).to.be.true();
+                done();
+            });
+
+            it('should match for .#.', (done) => {
+
+                expect(Helpers.routeMatcher(pattern, '.#.')).to.be.true();
+                done();
+            });
+
+            it('should match for .#.', (done) => {
+
+                expect(Helpers.routeMatcher(pattern, '..')).to.be.true();
+                done();
+            });
+        });
+    });
 });

--- a/test/integration-callback.js
+++ b/test/integration-callback.js
@@ -852,6 +852,60 @@ describe('positive integration tests - Callback api', () => {
         });
     });
 
+    describe('subscribe / unsubscribe (single queue with * route)', () => {
+
+        const queueName = 'test-subscribe-queue-with-star-routing-1';
+        const errorQueueName = `${queueName}_error`;
+        const subscriptionKey = 'a.*';
+        const routableObject = { event : 'a.b', name : 'bunnybus' };
+
+        before((done) => {
+
+            Async.waterfall([
+                instance._autoConnectChannel,
+                instance.deleteExchange.bind(instance, instance.config.globalExchange),
+                instance.deleteQueue.bind(instance, queueName),
+                instance.deleteQueue.bind(instance, errorQueueName)
+            ], done);
+        });
+
+        afterEach((done) => {
+
+            instance.unsubscribe(queueName, done);
+        });
+
+        after((done) => {
+
+            Async.waterfall([
+                instance._autoConnectChannel,
+                instance.deleteExchange.bind(instance, instance.config.globalExchange),
+                instance.deleteQueue.bind(instance, queueName),
+                instance.deleteQueue.bind(instance, errorQueueName)
+            ], done);
+        });
+
+        it.skip('should consume message (Object) from queue and acknowledge off', (done) => {
+
+            const handlers = {};
+            handlers[subscriptionKey] = (consumedMessage, ack) => {
+
+                expect(consumedMessage).to.be.equal(messageObject);
+                ack(null, done);
+            };
+
+            Async.waterfall([
+                instance.subscribe.bind(instance, queueName, handlers),
+                instance.publish.bind(instance, routableObject)
+            ],
+            (err) => {
+
+                if (err) {
+                    done(err);
+                }
+            });
+        });
+    });
+
     describe('subscribe / unsubscribe (multiple queue)', () => {
 
         const queueName1 = 'test-subscribe-multiple-queue-1';

--- a/test/integration-callback.js
+++ b/test/integration-callback.js
@@ -884,12 +884,66 @@ describe('positive integration tests - Callback api', () => {
             ], done);
         });
 
-        it.skip('should consume message (Object) from queue and acknowledge off', (done) => {
+        it('should consume message (Object) from queue and acknowledge off', (done) => {
 
             const handlers = {};
             handlers[subscriptionKey] = (consumedMessage, ack) => {
 
-                expect(consumedMessage).to.be.equal(messageObject);
+                expect(consumedMessage).to.be.equal(routableObject);
+                ack(null, done);
+            };
+
+            Async.waterfall([
+                instance.subscribe.bind(instance, queueName, handlers),
+                instance.publish.bind(instance, routableObject)
+            ],
+            (err) => {
+
+                if (err) {
+                    done(err);
+                }
+            });
+        });
+    });
+
+    describe('subscribe / unsubscribe (single queue with # route)', () => {
+
+        const queueName = 'test-subscribe-queue-with-hash-routing-1';
+        const errorQueueName = `${queueName}_error`;
+        const subscriptionKey = 'abc.#.xyz';
+        const routableObject = { event : 'abc.hello.world.xyz', name : 'bunnybus' };
+
+        before((done) => {
+
+            Async.waterfall([
+                instance._autoConnectChannel,
+                instance.deleteExchange.bind(instance, instance.config.globalExchange),
+                instance.deleteQueue.bind(instance, queueName),
+                instance.deleteQueue.bind(instance, errorQueueName)
+            ], done);
+        });
+
+        afterEach((done) => {
+
+            instance.unsubscribe(queueName, done);
+        });
+
+        after((done) => {
+
+            Async.waterfall([
+                instance._autoConnectChannel,
+                instance.deleteExchange.bind(instance, instance.config.globalExchange),
+                instance.deleteQueue.bind(instance, queueName),
+                instance.deleteQueue.bind(instance, errorQueueName)
+            ], done);
+        });
+
+        it('should consume message (Object) from queue and acknowledge off', (done) => {
+
+            const handlers = {};
+            handlers[subscriptionKey] = (consumedMessage, ack) => {
+
+                expect(consumedMessage).to.be.equal(routableObject);
                 ack(null, done);
             };
 

--- a/test/integration-callback.js
+++ b/test/integration-callback.js
@@ -856,8 +856,8 @@ describe('positive integration tests - Callback api', () => {
 
         const queueName = 'test-subscribe-queue-with-star-routing-1';
         const errorQueueName = `${queueName}_error`;
-        const subscriptionKey = 'a.*';
-        const routableObject = { event : 'a.b', name : 'bunnybus' };
+        const subscriptionKey = 'abc.*.xyz';
+        const routableObject = { event : 'abc.helloworld.xyz', name : 'bunnybus' };
 
         before((done) => {
 

--- a/test/integration-promise.js
+++ b/test/integration-promise.js
@@ -663,6 +663,104 @@ describe('positive integration tests - Promise api', () => {
         });
     });
 
+    describe('subscribe / unsubscribe (single queue with * route)', () => {
+
+        const queueName = 'test-subscribe-queue-with-star-routing-1';
+        const errorQueueName = `${queueName}_error`;
+        const subscriptionKey = 'abc.*.xyz';
+        const routableObject = { event : 'abc.helloworld.xyz', name : 'bunnybus' };
+
+        before(() => {
+
+            return instance._autoConnectChannel()
+                .then(instance.deleteExchange.bind(instance, instance.config.globalExchange))
+                .then(instance.deleteQueue.bind(instance, queueName))
+                .then(instance.deleteQueue.bind(instance, errorQueueName));
+        });
+
+        afterEach(() => {
+
+            return instance.unsubscribe(queueName);
+        });
+
+        after(() => {
+
+            return instance._autoConnectChannel()
+                .then(instance.deleteExchange.bind(instance, instance.config.globalExchange))
+                .then(instance.deleteQueue.bind(instance, queueName))
+                .then(instance.deleteQueue.bind(instance, errorQueueName));
+        });
+
+        it('should consume message (Object) from queue and acknowledge off', () => {
+
+            return new Promise((resolve, reject) => {
+
+                const handlers = {};
+
+                handlers[subscriptionKey] = (consumedMessage, ack) => {
+
+                    expect(consumedMessage).to.be.equal(routableObject);
+
+                    return ack()
+                        .then(resolve);
+                };
+
+                return instance.subscribe(queueName, handlers)
+                    .then(instance.publish.bind(instance, routableObject))
+                    .catch(reject);
+            });
+        });
+    });
+
+    describe('subscribe / unsubscribe (single queue with * route)', () => {
+
+        const queueName = 'test-subscribe-queue-with-hash-routing-1';
+        const errorQueueName = `${queueName}_error`;
+        const subscriptionKey = 'abc.#.xyz';
+        const routableObject = { event : 'abc.hello.world.xyz', name : 'bunnybus' };
+
+        before(() => {
+
+            return instance._autoConnectChannel()
+                .then(instance.deleteExchange.bind(instance, instance.config.globalExchange))
+                .then(instance.deleteQueue.bind(instance, queueName))
+                .then(instance.deleteQueue.bind(instance, errorQueueName));
+        });
+
+        afterEach(() => {
+
+            return instance.unsubscribe(queueName);
+        });
+
+        after(() => {
+
+            return instance._autoConnectChannel()
+                .then(instance.deleteExchange.bind(instance, instance.config.globalExchange))
+                .then(instance.deleteQueue.bind(instance, queueName))
+                .then(instance.deleteQueue.bind(instance, errorQueueName));
+        });
+
+        it('should consume message (Object) from queue and acknowledge off', () => {
+
+            return new Promise((resolve, reject) => {
+
+                const handlers = {};
+
+                handlers[subscriptionKey] = (consumedMessage, ack) => {
+
+                    expect(consumedMessage).to.be.equal(routableObject);
+
+                    return ack()
+                        .then(resolve);
+                };
+
+                return instance.subscribe(queueName, handlers)
+                    .then(instance.publish.bind(instance, routableObject))
+                    .catch(reject);
+            });
+        });
+    });
+
     describe('subscribe / unsubscribe (multiple queue)', () => {
 
         const queueName1 = 'test-subscribe-multiple-queue-1';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixed the bug around wildcards and RMQ subscriptions.  The initial implementations allowed for wild cards (`#`, `*`) to be used against the `consume` interface of RMQ.  But when messages were sent back down stream to `bunnyBus`, the routes did not match the routes used with the handlers set in the subscription call because logic was not implemented to do any wild card substitutions.  To support this, pattern matching logic had to be written around dynamic `regex` generation.  A lot of test were put in place to prove the rigor of the runtime for this bug fix.

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
 * #62 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
While no messages were ever lost when a message was subscribed down and missed by the handler because by default, `bunnyBus` forwards all messages with processing issues to the error queue; we do want to make sure the subscriber runs in parity with the route key binding language of RMQ.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Documentation only (no changes to either `lib/` or `test/` files)
- [x] Bug fix (non-breaking change which fixes an issue. you didn't modify existing tests)
- [ ] New feature (non-breaking change which adds functionality. you added at least one new test)
- [ ] Breaking change (fix or feature that would cause existing functionality to change. you had to modify existing tests.)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/xogroup/bunnybus/blob/master/.github/CONTRIBUTING.md) document.
- [x] My code follows the [Hapi.js style guide](https://github.com/hapijs/contrib/blob/master/Style.md).
- [x] I have updated the documentation as needed.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.