### PR TITLE
refactored public interface to only include promisification and moved…

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -223,8 +223,13 @@ class BunnyBus extends EventEmitter{
         callback = Helpers.reduceCallback(options, callback);
 
         if (callback === undefined) {
-            return Helpers.toPromise($.promise, $.createExchange, name, type, options);
+            return Helpers.toPromise($.promise, $._createExchange, name, type, options);
         }
+
+        $._createExchange(name, type, options, callback);
+    }
+
+    _createExchange(name, type, options, callback) {
 
         if (!$.hasChannel) {
             callback(new Exceptions.NoChannelError());
@@ -240,8 +245,13 @@ class BunnyBus extends EventEmitter{
         callback = Helpers.reduceCallback(options, callback);
 
         if (callback === undefined) {
-            return Helpers.toPromise($.promise, $.deleteExchange, name, options);
+            return Helpers.toPromise($.promise, $._deleteExchange, name, options);
         }
+
+        $._deleteExchange(name, options, callback);
+    }
+
+    _deleteExchange(name, options, callback) {
 
         if (!$.hasChannel) {
             callback(new Exceptions.NoChannelError());
@@ -256,8 +266,13 @@ class BunnyBus extends EventEmitter{
         callback = Helpers.reduceCallback(callback);
 
         if (callback === undefined) {
-            return Helpers.toPromise($.promise, $.checkExchange, name);
+            return Helpers.toPromise($.promise, $._checkExchange, name);
         }
+
+        $._checkExchange(name, callback);
+    }
+
+    _checkExchange(name, callback) {
 
         if (!$.hasChannel) {
             callback(new Exceptions.NoChannelError());
@@ -274,8 +289,13 @@ class BunnyBus extends EventEmitter{
         callback = Helpers.reduceCallback(options, callback);
 
         if (callback === undefined) {
-            return Helpers.toPromise($.promise, $.createQueue, name, options);
+            return Helpers.toPromise($.promise, $._createQueue, name, options);
         }
+
+        $._createQueue(name, options, callback);
+    }
+
+    _createQueue(name, options, callback) {
 
         if (!$.hasChannel) {
             callback(new Exceptions.NoChannelError());
@@ -290,8 +310,13 @@ class BunnyBus extends EventEmitter{
         callback = Helpers.reduceCallback(options, callback);
 
         if (callback === undefined) {
-            return Helpers.toPromise($.promise, $.deleteQueue, name, options);
+            return Helpers.toPromise($.promise, $._deleteQueue, name, options);
         }
+
+        $._deleteQueue(name, options, callback);
+    }
+
+    _deleteQueue(name, options, callback) {
 
         if (!$.hasChannel) {
             callback(new Exceptions.NoChannelError());
@@ -306,8 +331,13 @@ class BunnyBus extends EventEmitter{
         callback = Helpers.reduceCallback(callback);
 
         if (callback === undefined) {
-            return Helpers.toPromise($.promise, $.checkQueue, name);
+            return Helpers.toPromise($.promise, $._checkQueue, name);
         }
+
+        $._checkQueue(name, callback);
+    }
+
+    _checkQueue(name, callback) {
 
         if (!$.hasChannel) {
             callback(new Exceptions.NoChannelError());
@@ -322,8 +352,13 @@ class BunnyBus extends EventEmitter{
         callback = Helpers.reduceCallback(options, callback);
 
         if (callback === undefined) {
-            return Helpers.toPromise($.promise, $.send, message, queue, options);
+            return Helpers.toPromise($.promise, $._send, message, queue, options);
         }
+
+        $._send(message, queue, options, callback);
+    }
+
+    _send(message, queue, options, callback) {
 
         const routeKey = Helpers.reduceRouteKey(null, options, message);
         const source = (options && options.source);
@@ -368,8 +403,13 @@ class BunnyBus extends EventEmitter{
         callback = Helpers.reduceCallback(options, callback);
 
         if (callback === undefined) {
-            return Helpers.toPromise($.promise, $.get, queue, options);
+            return Helpers.toPromise($.promise, $._get, queue, options);
         }
+
+        $._get(queue, options, callback);
+    }
+
+    _get(queue, options, callback) {
 
         if (!$.hasChannel) {
             callback(new Exceptions.NoChannelError());
@@ -384,8 +424,13 @@ class BunnyBus extends EventEmitter{
         callback = Helpers.reduceCallback(options, callback);
 
         if (callback === undefined) {
-            return Helpers.toPromise($.promise, $.getAll, queue, handler, options);
+            return Helpers.toPromise($.promise, $._getAll, queue, handler, options);
         }
+
+        $._getAll(queue, handler, options, callback);
+    }
+
+    _getAll(queue, handler, options, callback) {
 
         const getOptions = (options && options.get);
         const meta = (options && options.meta);
@@ -432,8 +477,13 @@ class BunnyBus extends EventEmitter{
         callback = Helpers.reduceCallback(options, callback);
 
         if (callback === undefined) {
-            return Helpers.toPromise($.promise, $.publish, message, options);
+            return Helpers.toPromise($.promise, $._publish, message, options);
         }
+
+        $._publish(message, options, callback);
+    }
+
+    _publish(message, options, callback) {
 
         const globalExchange = (options && options.globalExchange) || $.config.globalExchange;
         const routeKey = Helpers.reduceRouteKey(null, options, message);
@@ -492,8 +542,13 @@ class BunnyBus extends EventEmitter{
         callback = Helpers.reduceCallback(options, callback);
 
         if (callback === undefined) {
-            return Helpers.toPromise($.promise, $.subscribe, queue, handlers, options);
+            return Helpers.toPromise($.promise, $._subscribe, queue, handlers, options);
         }
+
+        $._subscribe(queue, handlers, options, callback);
+    }
+
+    _subscribe(queue, handlers, options, callback) {
 
         const $S = $.subscriptions;
 
@@ -615,8 +670,13 @@ class BunnyBus extends EventEmitter{
         callback = Helpers.reduceCallback(callback);
 
         if (callback === undefined) {
-            return Helpers.toPromise($.promise, $.unsubscribe, queue);
+            return Helpers.toPromise($.promise, $._unsubscribe, queue);
         }
+
+        $._unsubscribe(queue, callback);
+    }
+
+    _unsubscribe(queue, callback) {
 
         const $S = $.subscriptions;
 

--- a/test/node6/helpers.js
+++ b/test/node6/helpers.js
@@ -43,7 +43,7 @@ describe('helpers', () => {
 
         it('should create only unique tokens', (done) => {
 
-            const iterations = 10000;
+            const iterations = 1000;
 
             Async.times(
                 iterations,


### PR DESCRIPTION
… actual processing to private functions

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Refactored all public functions with dual `callback` and `promise` interface to now only execute once.

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
* #76 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Documentation only (no changes to either `lib/` or `test/` files)
- [x] Bug fix (non-breaking change which fixes an issue. you didn't modify existing tests)
- [ ] New feature (non-breaking change which adds functionality. you added at least one new test)
- [ ] Breaking change (fix or feature that would cause existing functionality to change. you had to modify existing tests.)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/xogroup/bunnybus/blob/master/.github/CONTRIBUTING.md) document.
- [x] My code follows the [Hapi.js style guide](https://github.com/hapijs/contrib/blob/master/Style.md).
- [x] I have updated the documentation as needed.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.