### PR TITLE
Throw bunnybus exception on malformed message

### DIFF
--- a/API.md
+++ b/API.md
@@ -1933,6 +1933,7 @@ All `BunnyBus` errors are extended from the native `Error` class.
 - `IncompatibleLoggerError` - thrown when the logger interface contract is not met when `instance.logger` is set.
 - `NoConnectionError` - thrown when no connection exist
 - `NoChannelError` - thrown when no channel exist
+- `NoHeaderFieldError` - thrown when an incoming message lacks a header field
 - `NoRouteKeyError` - thrown when no route key can be found.  Lookup is done against `payload.properties.headers.routeKey`, `options.routeKey`, `message.event` and `payload.fields.routingKey` in that order.
 - `SubscriptionExistError` - thrown when `subscribe()` is called and handlers have already been registered against the queue
 - `SubscriptionBlockedError` - thrown when `subscribe()` is called and the queue is in a desired state of blocked.  The handlers would still have registered, but it would take an [`unblock()`](#unblockqueue) call to allow for the handlers to continue its subscriptions.

--- a/lib/exceptions/index.js
+++ b/lib/exceptions/index.js
@@ -3,6 +3,7 @@
 module.exports = {
     NoConnectionError       : require('./noConnectionError'),
     NoChannelError          : require('./noChannelError'),
+    NoHeaderFieldError      : require('./noHeaderFieldError'),
     NoRouteKeyError         : require('./noRouteKeyError'),
     SubscriptionExistError  : require('./subscriptionExistError'),
     SubscriptionBlockedError: require('./subscriptionBlockedError'),

--- a/lib/helpers/parsePayload.js
+++ b/lib/helpers/parsePayload.js
@@ -1,6 +1,12 @@
 'use strict';
 
+const Exceptions = require('../exceptions');
+
 const parsePayload = (payload) => {
+
+    if ( payload.properties.headers === undefined ) {
+        throw new Exceptions.NoHeaderFieldError('No header field on incoming message, refusing to parse.');
+    }
 
     return {
         message : payload.properties.headers.isBuffer ? payload.content : JSON.parse(payload.content.toString()),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

This fixes the case for AMQP valid but irregular messages entirely lacking a header field. In these cases we will now throw an explicit exception with details instead of a vague undefined error.

I will provide a follow up PR with an opt-in mode to repair these types of messages.

## Description
AMQP 0.9.1 does not strictly require headers on messages despite being very common practice. This surfaced when attempting to receive messages from php-amqplib which were lacking a header. 

This PR now makes those problems result in an explicit exception explaining the problem.

This PR is not covered by a test because amqplib does not allow publishing of a message without headers, nor will rabbitmq allow insertion of a message without headers. 

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

php-amqplib does not include a message header by default. This is technically allowable by spec. Note that php-amqplib should not be confused with php-amqp which leverages the rabbitmq c amqp client and correctly includes a header.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Documentation only (no changes to either `lib/` or `test/` files)
- [x] Bug fix (non-breaking change which fixes an issue. you didn't modify existing tests)
- [ ] New feature (non-breaking change which adds functionality. you added at least one new test)
- [ ] Breaking change (fix or feature that would cause existing functionality to change. you had to modify existing tests.)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/tenna-llc/bunnybus/blob/master/.github/CONTRIBUTING.md) document.
- [x] My code follows the [Hapi.js style guide](https://github.com/hapijs/contrib/blob/master/Style.md).
- [x] I have updated the documentation as needed.
- [ ] I have added tests to cover my changes. **EXPLAINED IN PR**
- [x] All new and existing tests passed.