### PR TITLE
Fix routekey priority issue breaking requeues in some circumstances

### DIFF
--- a/lib/helpers/reduceRouteKey.js
+++ b/lib/helpers/reduceRouteKey.js
@@ -10,12 +10,12 @@ const reduceRouteKey = (payload, options, message) => {
         return options.routeKey;
     }
 
-    if (payload && payload.fields && payload.fields.routingKey) {
-        return payload.fields.routingKey;
-    }
-
     if (message && message.event) {
         return message.event;
+    }
+
+    if (payload && payload.fields && payload.fields.routingKey) {
+        return payload.fields.routingKey;
     }
 
     return undefined;

--- a/test/helpers/reduceRouteKey.js
+++ b/test/helpers/reduceRouteKey.js
@@ -66,33 +66,33 @@ describe('Helpers', () => {
             expect(result).to.be.equal(options.routeKey);
         });
 
-        it('should return from payload.fields.routingKey when options is empty', () => {
+        it('should return from message.event when options is empty', () => {
 
             const result = Helpers.reduceRouteKey(payloadFields, {}, message);
 
-            expect(result).to.be.equal(payloadFields.fields.routingKey);
+            expect(result).to.be.equal(message.event);
         });
 
-        it('should return from payload.fields.routingKey when options is null', () => {
+        it('should return from message.event when options is null', () => {
 
             const result = Helpers.reduceRouteKey(payloadFields, null, message);
 
+            expect(result).to.be.equal(message.event);
+        });
+
+
+        it('should return from payload.fields.routingKey when options is empty and fields is empty', () => {
+
+            const result = Helpers.reduceRouteKey(payloadFields, {}, {});
+
             expect(result).to.be.equal(payloadFields.fields.routingKey);
         });
 
+        it('should return from payload.fields.routingKey when options is null and fields is null', () => {
 
-        it('should return from message.event when options is empty and fields is empty', () => {
+            const result = Helpers.reduceRouteKey(payloadFields, null, null);
 
-            const result = Helpers.reduceRouteKey({}, {}, message);
-
-            expect(result).to.be.equal(message.event);
-        });
-
-        it('should return from message.event when options is null and fields is null', () => {
-
-            const result = Helpers.reduceRouteKey(null, null, message);
-
-            expect(result).to.be.equal(message.event);
+            expect(result).to.be.equal(payloadFields.fields.routingKey);
         });
 
         it('should return undefined when all input is falsy', () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
When we fire off a requeue we emit the message directly into the queue. This means we emit a different route key at the field level then expected on the message. 

An earlier change in routekey precedence made it so that `normalizeMessages` and requeues were broken when used together.

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Documentation only (no changes to either `lib/` or `test/` files)
- [ ] Bug fix (non-breaking change which fixes an issue. you didn't modify existing tests)
- [ ] New feature (non-breaking change which adds functionality. you added at least one new test)
- [x] Breaking change (fix or feature that would cause existing functionality to change. you had to modify existing tests.)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/xogroup/bunnybus/blob/master/.github/CONTRIBUTING.md) document.
- [x] My code follows the [Hapi.js style guide](https://github.com/hapijs/contrib/blob/master/Style.md).
- [x] I have updated the documentation as needed.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.